### PR TITLE
Quote Annotations

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/templates/jicofo/deployment.yaml
+++ b/templates/jicofo/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/jicofo/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/jicofo/xmpp-secret.yaml") . | sha256sum }}
       {{- range $annotation, $value := mergeOverwrite .Values.global.podAnnotations .Values.jvb.podAnnotations }}
-        {{ $annotation }}: {{ $value }}
+        {{ $annotation }}: {{ $value|quote }}
       {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}

--- a/templates/jvb/deployment.yaml
+++ b/templates/jvb/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/jvb/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/jvb/xmpp-secret.yaml") . | sha256sum }}
       {{- range $annotation, $value := mergeOverwrite .Values.global.podAnnotations .Values.jvb.podAnnotations }}
-        {{ $annotation }}: {{ $value }}
+        {{ $annotation }}: {{ $value|quote }}
       {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}

--- a/templates/web/deployment.yaml
+++ b/templates/web/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/web/configmap.yaml") . | sha256sum }}
       {{- range $annotation, $value := mergeOverwrite .Values.global.podAnnotations .Values.web.podAnnotations }}
-        {{ $annotation }}: {{ $value }}
+        {{ $annotation }}: {{ $value|quote }}
       {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}


### PR DESCRIPTION
I stumpled upon a problem with setting annotations:

```yaml
global:
  podAnnotations:
    sidecar.istio.io/inject: "false"
```

will end up in 

```
synchronization of release 'jitsi-meet' in namespace 'workadventure' failed: installation failed: Deployment in version "v1" cannot be handled
as a Deployment: v1.Deployment.Spec: v1.DeploymentSpec.Template: v1.PodTemplateSpec.ObjectMeta: v1.ObjectMeta.Annotations: ReadString: expects " or n, but found f, error found in #10 byte of ...|/inject":fals
e},"lab|..., bigger context ...|5379ec984dc27aa75d8c7","sidecar.istio.io/inject":false},"labels":{"app":"jitsi-meet","app.kubernetes|...
```

Found that a proper solution is to quote the value in the annotations to ensure that it is a string.