### PR TITLE
Fix syntax and port convention

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -14,11 +14,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: stable-5390-3
+appVersion: stable-5963
 
 dependencies:
   - name: prosody

--- a/charts/prosody/templates/service.yaml
+++ b/charts/prosody/templates/service.yaml
@@ -9,12 +9,18 @@ spec:
   ports:
     - port: {{ index .Values.service.ports "bosh-insecure" }}
       protocol: TCP
-      name: bosh-insecure
+      name: tcp-bosh-insecure
+    - port: {{ index .Values.service.ports "bosh-secure" }}
+      protocol: TCP
+      name: tcp-bosh-secure
     - port: {{ index .Values.service.ports "xmpp-component" }}
       protocol: TCP
-      name: xmpp-component
+      name: tcp-xmpp-component
     - port: {{ index .Values.service.ports "xmpp-c2s" }}
       protocol: TCP
-      name: xmpp-c2
+      name: tcp-xmpp-c2
+    - port: {{ index .Values.service.ports "xmpp-s2s" }}
+      protocol: TCP
+      name: tcp-xmpp-s2
   selector:
     {{- include "prosody.selectorLabels" . | nindent 4 }}

--- a/templates/jvb/metrics-service.yaml
+++ b/templates/jvb/metrics-service.yaml
@@ -10,7 +10,7 @@ spec:
   ports:
     - port: 9888
       protocol: TCP
-      name: metrics
+      name: tcp-metrics
   selector:
   {{- include "jitsi-meet.jvb.selectorLabels" . | nindent 4 }}
   {{- end }}

--- a/templates/web/deployment.yaml
+++ b/templates/web/deployment.yaml
@@ -75,6 +75,6 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.web.extraVolumes }}
-    volumes:
-    {{- toYaml . | nindent 4 }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -206,4 +206,4 @@ prosody:
       name: '{{ include "prosody.fullname" . }}-common'
   image:
     repository: jitsi/prosody
-    tag: 'stable-5390-3'
+    tag: "stable-5963"


### PR DESCRIPTION
On my k8s rancher jitsi worked only after I defined all ports from prosody as service, also I adjusted the ports according to the [istio Port Naming Convention](https://istio.io/latest/docs/reference/config/analysis/ist0118/).

I also fixed a syntax error in templates/web/deployment.yaml with the extraVolumes and raised all containers to the current [version](https://github.com/jitsi/docker-jitsi-meet/releases/tag/stable-5963).
