### PR TITLE
Fix xmpp-websocket 403 response

### DIFF
--- a/templates/common-configmap.yaml
+++ b/templates/common-configmap.yaml
@@ -14,6 +14,7 @@ data:
   XMPP_GUEST_DOMAIN: {{ .Values.xmpp.guestDomain | default (printf "guest.%s" (include "jitsi-meet.xmpp.domain" .)) }}
   XMPP_RECORDER_DOMAIN: {{ .Values.xmpp.recorderDomain | default (printf "recorder.%s" (include "jitsi-meet.xmpp.domain" .)) }}
   XMPP_INTERNAL_MUC_DOMAIN: {{ .Values.xmpp.internalMucDomain | default (printf "internal-muc.%s" (include "jitsi-meet.xmpp.domain" .)) }}
+  XMPP_CROSS_DOMAIN: {{ .Values.xmpp.crossDomain | default "true" }}
   TZ: '{{ .Values.tz }}'
   {{- range $key, $value := .Values.extraCommonEnvs }}
   {{- if not (kindIs "invalid" $value) }}


### PR DESCRIPTION
I've found that without this set in configmap websockets endpoint return 403 response, at least it did in my case.
I'm not sure how it will affect other parts of the system but this allows me my jitsi to start call properly.