### PR TITLE
Fix jicofo labels and podAnnotations in template

### DIFF
--- a/templates/jicofo/deployment.yaml
+++ b/templates/jicofo/deployment.yaml
@@ -13,13 +13,13 @@ spec:
     metadata:
       labels:
         {{- include "jitsi-meet.jicofo.selectorLabels" . | nindent 8 }}
-      {{- range $label, $value := mergeOverwrite .Values.global.podLabels .Values.jvb.podLabels }}
+      {{- range $label, $value := mergeOverwrite .Values.global.podLabels .Values.jicofo.podLabels }}
         {{ $label }}: {{ $value }}
       {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/jicofo/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/jicofo/xmpp-secret.yaml") . | sha256sum }}
-      {{- range $annotation, $value := mergeOverwrite .Values.global.podAnnotations .Values.jvb.podAnnotations }}
+      {{- range $annotation, $value := mergeOverwrite .Values.global.podAnnotations .Values.jicofo.podAnnotations }}
         {{ $annotation }}: {{ $value|quote }}
       {{- end }}
     spec:


### PR DESCRIPTION
Seems like there is a copy-paste typo in the jicofo template, so the jicofo uses jvb labels and podAnnotations