### PR TITLE
feat(chart): Introduce Jibri to the chart

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -18,7 +18,7 @@ version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: stable-6726
+appVersion: stable-6726-2
 
 dependencies:
   - name: prosody

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -18,7 +18,7 @@ version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: stable-6726-2
+appVersion: stable-6865
 
 dependencies:
   - name: prosody

--- a/README.md
+++ b/README.md
@@ -95,6 +95,24 @@ Parameter | Description | Default
 `imagePullSecrets` | List of names of secrets resources containing private registry credentials | `[]`
 `enableAuth` | Enable authentication | `false`
 `enableGuests` | Enable guest access | `true`
+`jibri.enabled` | Enable Jibri service | `false`
+`jibri.persistence.enabled` | Enable persistent storage for Jibri recordings | `false`
+`jibri.persistence.size` | Jibri persistent storage size | `4Gi`
+`jibri.persistence.existingClaim` | Use pre-created PVC for Jibri | `(unset)`
+`jibri.persistence.storageClassName` | StorageClass to use with Jibri | `(unset)`
+`jibri.shm.enabled` | Allocate shared memory to Jibri pod | `false`
+`jibri.shm.useHost` | Pass `/dev/shm` from host to Jibri | `false`
+`jibri.shm.size` | Jibri shared memory size | `256Mi`
+`jibri.replicaCount` | Number of replica of the jibri pods | `1`
+`jibri.image.repository` | Name of the image to use for the jibri pods | `jitsi/jibri`
+`jibri.extraEnvs` | Map containing additional environment variables for jibri | '{}'
+`jibri.livenessProbe` | Map that holds the liveness probe, you can add parameters such as timeout or retries following the Kubernetes spec | A livenessProbe map
+`jibri.readinessProbe` | Map that holds the liveness probe, you can add parameters such as timeout or retries following the Kubernetes spec | A readinessProbe map
+`jibri.breweryMuc` | Name of the XMPP MUC used by jibri | `jibribrewery`
+`jibri.xmpp.user` | Name of the XMPP user used by jibri to authenticate | `jibri`
+`jibri.xmpp.password` | Password used by jibri to authenticate on the XMPP service | 10 random chars
+`jibri.recorder.user` | Name of the XMPP user used by jibri to record | `recorder`
+`jibri.recorder.password` | Password used by jibri to record on the XMPP service | 10 random chars
 `jicofo.replicaCount` | Number of replica of the jicofo pods | `1`
 `jicofo.image.repository` | Name of the image to use for the jicofo pods | `jitsi/jicofo`
 `jicofo.extraEnvs` | Map containing additional environment variables for jicofo | '{}'

--- a/templates/common-configmap.yaml
+++ b/templates/common-configmap.yaml
@@ -14,6 +14,9 @@ data:
   XMPP_GUEST_DOMAIN: {{ .Values.xmpp.guestDomain | default (printf "guest.%s" (include "jitsi-meet.xmpp.domain" .)) }}
   XMPP_RECORDER_DOMAIN: {{ .Values.xmpp.recorderDomain | default (printf "recorder.%s" (include "jitsi-meet.xmpp.domain" .)) }}
   XMPP_INTERNAL_MUC_DOMAIN: {{ .Values.xmpp.internalMucDomain | default (printf "internal-muc.%s" (include "jitsi-meet.xmpp.domain" .)) }}
+  {{- if .Values.jibri.enabled }}
+  ENABLE_RECORDING: "true"
+  {{- end }}
   TZ: '{{ .Values.tz }}'
   {{- range $key, $value := .Values.extraCommonEnvs }}
   {{- if not (kindIs "invalid" $value) }}

--- a/templates/common-configmap.yaml
+++ b/templates/common-configmap.yaml
@@ -9,7 +9,7 @@ data:
   ENABLE_GUESTS: {{ ternary "1" "0" .Values.enableGuests | quote }}
   PUBLIC_URL: {{ include "jitsi-meet.publicURL" . }}
   XMPP_DOMAIN: {{ include "jitsi-meet.xmpp.domain" . }}
-  XMPP_MUC_DOMAIN: {{ .Values.xmpp.muxDomain | default (printf "muc.%s" (include "jitsi-meet.xmpp.domain" .)) }}
+  XMPP_MUC_DOMAIN: {{ .Values.xmpp.mucDomain | default (printf "muc.%s" (include "jitsi-meet.xmpp.domain" .)) }}
   XMPP_AUTH_DOMAIN: {{ .Values.xmpp.authDomain | default (printf "auth.%s" (include "jitsi-meet.xmpp.domain" .)) }}
   XMPP_GUEST_DOMAIN: {{ .Values.xmpp.guestDomain | default (printf "guest.%s" (include "jitsi-meet.xmpp.domain" .)) }}
   XMPP_RECORDER_DOMAIN: {{ .Values.xmpp.recorderDomain | default (printf "recorder.%s" (include "jitsi-meet.xmpp.domain" .)) }}

--- a/templates/jibri/_helper.tpl
+++ b/templates/jibri/_helper.tpl
@@ -1,0 +1,18 @@
+
+{{- define "jitsi-meet.jibri.fullname" -}}
+{{ include "jitsi-meet.fullname" . }}-jibri
+{{- end -}}
+
+{{- define "jitsi-meet.jibri.labels" -}}
+{{ include "jitsi-meet.labels" . }}
+app.kubernetes.io/component: jibri
+{{- end -}}
+
+{{- define "jitsi-meet.jibri.selectorLabels" -}}
+{{ include "jitsi-meet.selectorLabels" . }}
+app.kubernetes.io/component: jibri
+{{- end -}}
+
+{{- define "jitsi-meet.jibri.secret" -}}
+{{ include "call-nested" (list . "prosody" "prosody.fullname") }}-jibri
+{{- end -}}

--- a/templates/jibri/configmap.yaml
+++ b/templates/jibri/configmap.yaml
@@ -1,0 +1,21 @@
+{{- if default false .Values.jibri.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "jitsi-meet.jibri.fullname" . }}
+  labels:
+    {{- include "jitsi-meet.jibri.labels" . | nindent 4 }}
+data:
+  XMPP_SERVER: '{{ include "jitsi-meet.xmpp.server" . }}'
+  JIBRI_BREWERY_MUC: '{{ .Values.jibri.breweryMuc }}'
+  JIBRI_RECORDING_DIR: '{{ .Values.jibri.recordingDir | default "/data/recordings" }}'
+  JIBRI_FINALIZE_RECORDING_SCRIPT_PATH: "/config/finalize.sh"
+  JIBRI_STRIP_DOMAIN_JID: muc
+  JIBRI_LOGS_DIR: "/data/logs"
+  DISPLAY: ":0"
+  {{- range $key, $value := .Values.jibri.extraEnvs }}
+  {{- if not (kindIs "invalid" $value) }}
+  {{ $key }}: {{ tpl $value $ | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/templates/jibri/configmap.yaml
+++ b/templates/jibri/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if default false .Values.jibri.enabled }}
+{{- if .Values.jibri.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/templates/jibri/deployment.yaml
+++ b/templates/jibri/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if default false .Values.jibri.enabled }}
+{{- if .Values.jibri.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/templates/jibri/deployment.yaml
+++ b/templates/jibri/deployment.yaml
@@ -34,11 +34,11 @@ spec:
           containerPort: 3333
         - name: http-api
           containerPort: 2222
-        {{- with default .Values.jvb.livenessProbe .Values.jvb.livenessProbeOverride }}
+        {{- with default .Values.jibri.livenessProbe .Values.jibri.livenessProbeOverride }}
         livenessProbe:
         {{- toYaml . | nindent 10 }}
         {{- end }}
-        {{- with default .Values.jvb.readinessProbe .Values.jvb.readinessProbeOverride }}
+        {{- with default .Values.jibri.readinessProbe .Values.jibri.readinessProbeOverride }}
         readinessProbe:
         {{- toYaml . | nindent 10 }}
         {{- end }}

--- a/templates/jibri/deployment.yaml
+++ b/templates/jibri/deployment.yaml
@@ -1,0 +1,89 @@
+{{- if default false .Values.jibri.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "jitsi-meet.jibri.fullname" . }}
+  labels:
+    {{- include "jitsi-meet.jibri.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.jibri.replicaCount | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "jitsi-meet.jibri.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "jitsi-meet.jibri.selectorLabels" . | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/jibri/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/jibri/xmpp-secret.yaml") . | sha256sum }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "jitsi-meet.serviceAccountName" . }}
+      containers:
+      - name: {{ .Chart.Name }}
+        securityContext:
+          privileged: true
+        image: "{{ .Values.jibri.image.repository }}:{{ default .Chart.AppVersion .Values.jibri.image.tag }}"
+        imagePullPolicy: {{ pluck "pullPolicy" .Values.jibri.image .Values.image | first }}
+        ports:
+        - name: http-internal
+          containerPort: 3333
+        - name: http-api
+          containerPort: 2222
+        {{- with default .Values.jvb.livenessProbe .Values.jvb.livenessProbeOverride }}
+        livenessProbe:
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with default .Values.jvb.readinessProbe .Values.jvb.readinessProbeOverride }}
+        readinessProbe:
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
+
+        envFrom:
+        - secretRef:
+            name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-jibri
+        - configMapRef:
+            name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-common
+        - configMapRef:
+            name: {{ include "jitsi-meet.jibri.fullname" . }}
+
+        resources:
+          {{- toYaml .Values.jibri.resources | nindent 12 }}
+
+        volumeMounts:
+        - name: jibri-data
+          mountPath: /data
+        - name: dev-snd
+          mountPath: /dev/snd
+        {{- if .Values.jibri.shm.enabled }}
+        - name: dev-shm
+          mountPath: /dev/shm
+        {{- end }}
+
+      volumes:
+      - name: jibri-data
+        {{- if .Values.jibri.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.jibri.persistence.existingClaim | default (include "jitsi-meet.jibri.fullname" .) }}
+        {{- else }}
+        emptyDir: {}
+        {{- end }}
+      - name: dev-snd
+        hostPath:
+          path: /dev/snd
+      {{- if .Values.jibri.shm.enabled }}
+      - name: dev-shm
+      {{-   if .Values.jibri.shm.useHost }}
+        hostPath:
+          path: /dev/shm
+      {{-   else }}
+        emptyDir:
+          medium: Memory
+          sizeLimit: {{ .Values.jibri.shm.size | default "256Mi" | quote }}
+      {{-   end }}
+      {{- end }}
+{{- end }}

--- a/templates/jibri/persistentvolumeclaim.yaml
+++ b/templates/jibri/persistentvolumeclaim.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.jibri.persistence.enabled (not .Values.jibri.persistence.existingClaim)}}
+{{- if and .Values.jibri.enabled .Values.jibri.persistence.enabled (not .Values.jibri.persistence.existingClaim)}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/templates/jibri/persistentvolumeclaim.yaml
+++ b/templates/jibri/persistentvolumeclaim.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.jibri.persistence.enabled (not .Values.jibri.persistence.existingClaim)}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "jitsi-meet.jibri.fullname" . }}
+  labels:
+    {{- include "jitsi-meet.jibri.labels" . | nindent 4 }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.jibri.persistence.size | quote }}
+  storageClassName: {{ .Values.jibri.persistence.storageClassName }}
+{{- end -}}

--- a/templates/jibri/persistentvolumeclaim.yaml
+++ b/templates/jibri/persistentvolumeclaim.yaml
@@ -12,5 +12,7 @@ spec:
   resources:
     requests:
       storage: {{ .Values.jibri.persistence.size | quote }}
-  storageClassName: {{ .Values.jibri.persistence.storageClassName }}
+  {{- with .Values.jibri.persistence.storageClassName }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
 {{- end -}}

--- a/templates/jibri/service.yaml
+++ b/templates/jibri/service.yaml
@@ -1,4 +1,4 @@
-{{- if default false .Values.jibri.enabled }}
+{{- if .Values.jibri.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/templates/jibri/service.yaml
+++ b/templates/jibri/service.yaml
@@ -1,0 +1,21 @@
+{{- if default false .Values.jibri.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "jitsi-meet.jibri.fullname" . }}
+  labels:
+    {{- include "jitsi-meet.jibri.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+  - name: http-internal
+    port: 3333
+    targetPort: 3333
+    protocol: TCP
+  - name: http-api
+    port: 2222
+    targetPort: 2222
+    protocol: TCP
+  selector:
+    {{- include "jitsi-meet.jibri.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/templates/jibri/xmpp-secret.yaml
+++ b/templates/jibri/xmpp-secret.yaml
@@ -1,4 +1,4 @@
-{{- if default false .Values.jibri.enabled }}
+{{- if .Values.jibri.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/templates/jibri/xmpp-secret.yaml
+++ b/templates/jibri/xmpp-secret.yaml
@@ -1,0 +1,14 @@
+{{- if default false .Values.jibri.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-jibri
+  labels:
+    {{- include "jitsi-meet.jibri.labels" . | nindent 4 }}
+type: Opaque
+data:
+  JIBRI_XMPP_USER: '{{ .Values.jibri.xmpp.user | b64enc }}'
+  JIBRI_XMPP_PASSWORD: '{{ default (randAlphaNum 10) .Values.jibri.xmpp.password | b64enc }}'
+  JIBRI_RECORDER_USER: '{{ .Values.jibri.recorder.user | b64enc }}'
+  JIBRI_RECORDER_PASSWORD: '{{ default (randAlphaNum 10) .Values.jibri.recorder.password | b64enc }}'
+{{- end }}

--- a/templates/jicofo/configmap.yaml
+++ b/templates/jicofo/configmap.yaml
@@ -7,6 +7,10 @@ metadata:
 data:
   JVB_BREWERY_MUC: '{{ .Values.jvb.breweryMuc }}'
   XMPP_SERVER: '{{ include "jitsi-meet.xmpp.server" . }}'
+  {{- if .Values.jibri.enabled }}
+  JIBRI_BREWERY_MUC: '{{ .Values.jibri.breweryMuc }}'
+  JIBRI_PENDING_TIMEOUT: '{{ .Values.jibri.timeout }}'
+  {{- end }}
   {{- range $key, $value := .Values.jicofo.extraEnvs }}
   {{- if not (kindIs "invalid" $value) }}
   {{ $key }}: {{ tpl $value $ | quote }}

--- a/templates/web/configmap.yaml
+++ b/templates/web/configmap.yaml
@@ -13,6 +13,10 @@ data:
   {{- if and .Values.jvb.websockets.enabled (eq $serverID "service") }}
   NGINX_RESOLVER: {{ required "(web.resolverIP) Please set an IP address of your KubeDNS service!" .Values.web.resolverIP }}
   {{- end }}
+  {{- if .Values.jibri.enabled }}
+  ENABLE_RECORDING: "true"
+  ENABLE_FILE_RECORDING_SERVICE_SHARING: "true"
+  {{- end }}
   {{- range $key, $value := .Values.web.extraEnvs }}
   {{- if not (kindIs "invalid" $value) }}
   {{ $key }}: {{ tpl $value $ | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -281,4 +281,4 @@ prosody:
   #     name: '{{ include "prosody.fullname" . }}-jibri'
   image:
     repository: jitsi/prosody
-    tag: 'stable-6726-2'
+    tag: 'stable-6865'

--- a/values.yaml
+++ b/values.yaml
@@ -281,4 +281,4 @@ prosody:
   #     name: '{{ include "prosody.fullname" . }}-jibri'
   image:
     repository: jitsi/prosody
-    tag: 'stable-6726'
+    tag: 'stable-6726-2'

--- a/values.yaml
+++ b/values.yaml
@@ -198,6 +198,56 @@ jvb:
         cpu: 20m
         memory: 32Mi
 
+jibri:
+  ## Enabling Jibri will allow users to record
+  ## and/or stream their meetings (e.g. to YouTube).
+  enabled: false
+
+  ## Enable persistent storage for local recordings.
+  ## If disabled, jibri pod will use a transient
+  ## emptyDir-backed storage instead.
+  persistence:
+    enabled: false
+    size: 4Gi
+    ## Set this to existing PVC name if you have one.
+    existingClaim:
+    storageClassName:
+
+  shm:
+    ## Set to true to enable "/dev/shm" mount.
+    ## May be required by built-in Chromium.
+    enabled: false
+    ## If "true", will use host's shared memory dir,
+    ## and if "false" — an emptyDir mount.
+    # useHost: false
+    # size: 256Mi
+
+  image:
+    repository: jitsi/jibri
+
+  breweryMuc: jibribrewery
+  timeout: 90
+
+  ## jibri XMPP user credentials:
+  xmpp:
+    user: jibri
+    password:
+
+  ## recorder XMPP user credentials:
+  recorder:
+    user: recorder
+    password:
+
+  livenessProbe:
+    exec:
+      command: ["pgrep", "java"]
+
+  readinessProbe:
+    exec:
+      command: ["pgrep", "java"]
+
+  extraEnvs: {}
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
@@ -226,6 +276,9 @@ prosody:
       name: '{{ include "prosody.fullname" . }}-jvb'
   - configMapRef:
       name: '{{ include "prosody.fullname" . }}-common'
+  ## Uncomment this if you want to use jibri:
+  # - secretRef:
+  #     name: '{{ include "prosody.fullname" . }}-jibri'
   image:
     repository: jitsi/prosody
     tag: 'stable-6726'


### PR DESCRIPTION
Hello again! :)

This PR adds (almost) everything one needs to deploy Jitsi Meet in Kubernetes with fully-featured recording and livestreaming support.

Known limitations:
1. It's still necessary to prepare the host node beforehand by loading the `snd-aloop` kernel module and adding it to the autoload list;
2. AFAIK, one Jibri pod gives the ability to record/stream only one room at a time, and we'd need to set up multiple Jibri pods with different configs (JIDs, "nicks", etc.) to scale it properly, which requires extra work and goes beyond the scope of this chart.

Thoughts about those limitations:
1. I was thinking about adding an init-container that'd load the module for us if needed, but that would require mounting the `/lib/modules` directory from the host, which is a questionable thing to do. It also wouldn't be 100% reliable, since some distros store their modules in `/usr/lib`, `/lib64`, `/usr/lib64` and so on.
2. Technically it's possible to generate multiple `ConfigMap`s for multiple Jibri instances with template-generated JIDs and nicknames. Is it feasible for us to go that far? :)

As always, do not hesitate to ask or let me know what you think.