### PR TITLE
Add ingressClassName to spec

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -104,12 +104,11 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
-Ingress no longer supports annotations and should use ingressClassName
+Ingress no longer supports annotations and should use ingressClassName.
+Check if its defined in values before settings it
 */}}
 {{- define "ingress.className" -}}
-{{- if .Values.web.ingress.ingressClassName }}
-{{- if semverCompare ">=1.19-0" $kubeVersion -}}
-ingressClassName: {{ .web.ingress.ingressClassName }}
-{{- end }}
-{{- end }}
-{{- end }}
+{{- if .Values.web.ingress.ingressClassName -}}
+ingressClassName: {{ .Values.web.ingress.ingressClassName }}
+{{- end -}}
+{{- end -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -102,3 +102,14 @@ Create the name of the service account to use
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Ingress no longer supports annotations and should use ingressClassName
+*/}}
+{{- define "ingress.className" -}}
+{{- if .Values.web.ingress.ingressClassName }}
+{{- if semverCompare ">=1.19-0" $kubeVersion -}}
+ingressClassName: {{ .web.ingress.ingressClassName }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -102,13 +102,3 @@ Create the name of the service account to use
 {{- end -}}
 {{- end -}}
 {{- end -}}
-
-{{/*
-Ingress no longer supports annotations and should use ingressClassName.
-Check if its defined in values before settings it
-*/}}
-{{- define "ingress.className" -}}
-{{- if .Values.web.ingress.ingressClassName -}}
-ingressClassName: {{ .Values.web.ingress.ingressClassName }}
-{{- end -}}
-{{- end -}}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -19,7 +19,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- include "ingress.className" .| nindent 2 }}
+{{- if semverCompare ">=1.19-0" $kubeVersion }}
+{{- include "ingress.className" . | nindent 2 }}
+{{- end }}
 {{- if .Values.web.ingress.tls }}
   tls:
   {{- range .Values.web.ingress.tls }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -19,6 +19,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+{{- if semverCompare ">=1.19-0" $kubeVersion -}}
+  ingressClassName: {{ .web.ingress.ingressClassName }}
+{{- end }}
 {{- if .Values.web.ingress.tls }}
   tls:
   {{- range .Values.web.ingress.tls }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -19,8 +19,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if semverCompare ">=1.19-0" $kubeVersion }}
-{{- include "ingress.className" . | nindent 2 }}
+{{- if and .Values.web.ingress.ingressClassName (semverCompare ">=1.19-0" $kubeVersion) }}
+  ingressClassName: {{ .Values.web.ingress.ingressClassName }}
 {{- end }}
 {{- if .Values.web.ingress.tls }}
   tls:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -19,9 +19,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-{{- if semverCompare ">=1.19-0" $kubeVersion -}}
-  ingressClassName: {{ .web.ingress.ingressClassName }}
-{{- end }}
+  {{- include "ingress.className" .| nindent 2 }}
 {{- if .Values.web.ingress.tls }}
   tls:
   {{- range .Values.web.ingress.tls }}

--- a/values.yaml
+++ b/values.yaml
@@ -31,6 +31,7 @@ web:
 
   ingress:
     enabled: false
+    # ingressClassName: "nginx-ingress-0"
     annotations: {}
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
To ensure we get an IP address, Ingresses must use ingressClassName for >= 1.19, annotations are no longer supported.