### PR TITLE
Update Jitsi Meet Exporter to `1.1.9`

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.2.0
+version: 1.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/values.yaml
+++ b/values.yaml
@@ -181,7 +181,7 @@ jvb:
     enabled: false
     image:
       repository: docker.io/systemli/prometheus-jitsi-meet-exporter
-      tag: 1.1.6
+      tag: 1.1.9
       pullPolicy: IfNotPresent
     serviceMonitor:
       enabled: true


### PR DESCRIPTION
See the Releases since `1.1.6`: https://github.com/systemli/prometheus-jitsi-meet-exporter/compare/1.1.6...1.1.9

Latest Release: https://github.com/systemli/prometheus-jitsi-meet-exporter/releases/tag/1.1.9