### PR TITLE
Splitted UDPPort into UDPPort and nodePort values

### DIFF
--- a/templates/jvb/service.yaml
+++ b/templates/jvb/service.yaml
@@ -17,7 +17,7 @@ spec:
   ports:
     - port: {{ default 10000 .Values.jvb.UDPPort }}
       {{- if or (eq .Values.jvb.service.type "NodePort") (eq .Values.jvb.service.type "LoadBalancer") }}
-      nodePort: {{ .Values.jvb.UDPPort }}
+      nodePort: {{ .Values.jvb.nodePort }}
       {{- end }}
       protocol: UDP
       name: rtp-udp

--- a/values.yaml
+++ b/values.yaml
@@ -134,6 +134,9 @@ jvb:
   stunServers: 'meet-jit-si-turnrelay.jitsi.net:443'
   useHostPort: false
   UDPPort: 10000
+  ## nodePort used if service type is set to 'LoadBalancer' or 'NodePort'. 
+  ## It will be automatically allocated if it is left with default value
+  nodePort: 0
   service:
     enabled:
     type: ClusterIP


### PR DESCRIPTION
Approach suggested in order to deploy this chart with JVB as a Service of type **LoadBalancer** easily (related with #22 )

By default, if the jvb.service.type value is set to 'LoadBalancer' or 'NodePort', the UDPPort value (10000 by default) is reused in templates/jvb/service.yaml as its nodePort attribute. However, this setup fails to deploy in Kubernetes due to the fact that the Kubernetes control plane expects this port to be in the default range 30000-32767. 

For that reason, we found it useful for our deployment to define a new value in the values.yaml, **nodePort**, to distinguish it from the UDPPort, avoiding mixing these two concepts. Leaving this value set to 0 (default value) will make Kubernetes control plane allocate automatically a port number in the expected range. 

The chart was successfully tested following this approach. 