### PR TITLE
Allow Jibri deployment update strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Parameter | Description | Default
 `jibri.xmpp.password` | Password used by jibri to authenticate on the XMPP service | 10 random chars
 `jibri.recorder.user` | Name of the XMPP user used by jibri to record | `recorder`
 `jibri.recorder.password` | Password used by jibri to record on the XMPP service | 10 random chars
+`jibri.strategy` | Depolyment update strategy and parameters | `(unset)`
 `jicofo.replicaCount` | Number of replica of the jicofo pods | `1`
 `jicofo.image.repository` | Name of the image to use for the jicofo pods | `jitsi/jicofo`
 `jicofo.extraEnvs` | Map containing additional environment variables for jicofo | '{}'

--- a/templates/jibri/deployment.yaml
+++ b/templates/jibri/deployment.yaml
@@ -101,4 +101,8 @@ spec:
           sizeLimit: {{ .Values.jibri.shm.size | default "256Mi" | quote }}
       {{-   end }}
       {{- end }}
+
+  {{- if .Values.jibri.strategy }}
+  {{ .Values.jibri.strategy }}
+  {{- end }}
 {{- end }}

--- a/templates/jibri/deployment.yaml
+++ b/templates/jibri/deployment.yaml
@@ -103,6 +103,7 @@ spec:
       {{- end }}
 
   {{- if .Values.jibri.strategy }}
-  {{ .Values.jibri.strategy }}
+  strategy:
+    {{ toYaml .Values.jibri.strategy | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -297,9 +297,9 @@ jibri:
   ## the Jibri deployment.
   ## This will be important depending on your persistence
   ## settings.
-  ## Default strategy is "rolling update".
+  ## Default strategy is "RollingUpdate".
   #strategy:
-  #  type: Recreate
+  #  type: RollingUpdate
 
   image:
     repository: jitsi/jibri

--- a/values.yaml
+++ b/values.yaml
@@ -292,6 +292,15 @@ jibri:
     # useHost: false
     # size: 256Mi
 
+  ## Configure the update strategy for this deployment
+  ## The node "strategy" will be imported literally into
+  ## the Jibri deployment.
+  ## This will be important depending on your persistence
+  ## settings.
+  ## Default strategy is "rolling update".
+  #strategy:
+  #  type: Recreate
+
   image:
     repository: jitsi/jibri
 


### PR DESCRIPTION
When using persistent volumes in RWO mode, rolling upgrades to the Jibri deployment will fail (two pods trying to access the same PV). For such cases, "replace" strategy is a more feasible approach, though disruptive.

This change allows to configure the Jibri deployment upgrade strategy, maintaining the current behaviour as a default.