### PR TITLE
fix: use statefule servicename based on template

### DIFF
--- a/charts/prosody/templates/statefulset.yaml
+++ b/charts/prosody/templates/statefulset.yaml
@@ -9,7 +9,7 @@ metadata:
     {{ toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  serviceName: "prosody"
+  serviceName: "{{ include "prosody.fullname" . }}"
   replicas: 1
   selector:
     matchLabels:


### PR DESCRIPTION
it is not possible to deploy multiple helm-releases / instance in the same namespace ....