### PR TITLE
Fix typo in service.yaml

### DIFF
--- a/templates/jvb/service.yaml
+++ b/templates/jvb/service.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- include "jitsi-meet.jvb.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.jvb.service.type }}
-  {{- with .Values.jvb.service.LoadbalancerIP }}
+  {{- with .Values.jvb.service.loadBalancerIP }}
   loadBalancerIP: {{ . }}
   {{- end }}
   ports:


### PR DESCRIPTION
Change load balancer IP field from LoadbalancerIP to loadBalancerIP to match the Kubernetes field name