### PR TITLE
feat(chart): add jigasi

### DIFF
--- a/templates/jicofo/configmap.yaml
+++ b/templates/jicofo/configmap.yaml
@@ -11,6 +11,10 @@ data:
   JIBRI_BREWERY_MUC: '{{ .Values.jibri.breweryMuc }}'
   JIBRI_PENDING_TIMEOUT: '{{ .Values.jibri.timeout }}'
   {{- end }}
+  {{- if .Values.jigasi.enabled }}
+  JIGASI_BREWERY_MUC: '{{ .Values.jigasi.breweryMuc }}'
+  JIGASI_SIP_URI: "available"
+  {{- end }}
   {{- range $key, $value := .Values.jicofo.extraEnvs }}
   {{- if not (kindIs "invalid" $value) }}
   {{ $key }}: {{ tpl $value $ | quote }}

--- a/templates/jigasi/_helper.tpl
+++ b/templates/jigasi/_helper.tpl
@@ -1,0 +1,18 @@
+
+{{- define "jitsi-meet.jigasi.fullname" -}}
+{{ include "jitsi-meet.fullname" . }}-jigasi
+{{- end -}}
+
+{{- define "jitsi-meet.jigasi.labels" -}}
+{{ include "jitsi-meet.labels" . }}
+app.kubernetes.io/component: jigasi
+{{- end -}}
+
+{{- define "jitsi-meet.jigasi.selectorLabels" -}}
+{{ include "jitsi-meet.selectorLabels" . }}
+app.kubernetes.io/component: jigasi
+{{- end -}}
+
+{{- define "jitsi-meet.jigasi.secret" -}}
+{{ include "call-nested" (list . "prosody" "prosody.fullname") }}-jigasi
+{{- end -}}

--- a/templates/jigasi/configmap.yaml
+++ b/templates/jigasi/configmap.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.jigasi.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "jitsi-meet.jigasi.fullname" . }}
+  labels:
+    {{- include "jitsi-meet.jigasi.labels" . | nindent 4 }}
+data:
+  JIGASI_BREWERY_MUC: '{{ .Values.jigasi.breweryMuc }}'
+  XMPP_SERVER: '{{ include "jitsi-meet.xmpp.server" . }}'
+  {{- range $key, $value := .Values.jigasi.extraEnvs }}
+  {{- if not (kindIs "invalid" $value) }}
+  {{ $key }}: {{ tpl $value $ | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/templates/jigasi/deployment.yaml
+++ b/templates/jigasi/deployment.yaml
@@ -1,0 +1,74 @@
+{{- if and .Values.jigasi.enabled (not .Values.jigasi.useExternalJigasi) }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "jitsi-meet.jigasi.fullname" . }}
+  labels:
+    {{- include "jitsi-meet.jigasi.labels" . | nindent 4 }}
+  {{- with .Values.jigasi.annotations }}
+  annotations:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.jigasi.replicaCount | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "jitsi-meet.jigasi.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "jitsi-meet.jigasi.selectorLabels" . | nindent 8 }}
+      {{- range $label, $value := mergeOverwrite .Values.global.podLabels .Values.jigasi.podLabels }}
+        {{ $label }}: {{ $value }}
+      {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/jigasi/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/jigasi/xmpp-secret.yaml") . | sha256sum }}
+      {{- range $annotation, $value := mergeOverwrite .Values.global.podAnnotations .Values.jigasi.podAnnotations }}
+        {{ $annotation }}: {{ $value|quote }}
+      {{- end }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "jitsi-meet.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.jigasi.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.jigasi.securityContext | nindent 12 }}
+          image: "{{ .Values.jigasi.image.repository }}:{{ default .Chart.AppVersion .Values.jigasi.image.tag }}"
+          imagePullPolicy: {{ pluck "pullPolicy" .Values.jigasi.image .Values.image | first }}
+          envFrom:
+          - secretRef:
+              name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-jigasi
+          - configMapRef:
+              name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-common
+          - configMapRef:
+              name: {{ include "jitsi-meet.jigasi.fullname" . }}
+          {{- with .Values.jigasi.livenessProbe }}
+          livenessProbe:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.jigasi.readinessProbe }}
+          readinessProbe:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.jigasi.resources | nindent 12 }}
+
+      {{- with .Values.jigasi.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.jigasi.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.jigasi.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+{{- end }}

--- a/templates/jigasi/xmpp-secret.yaml
+++ b/templates/jigasi/xmpp-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-jigasi
+  labels:
+    {{- include "jitsi-meet.jigasi.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if .Values.jigasi.enabled }}
+  JIGASI_XMPP_PASSWORD: '{{ default (randAlphaNum 10) .Values.jigasi.xmpp.password | b64enc }}'
+  {{- end }}

--- a/templates/jigasi/xmpp-secret.yaml
+++ b/templates/jigasi/xmpp-secret.yaml
@@ -7,5 +7,6 @@ metadata:
 type: Opaque
 data:
   {{- if .Values.jigasi.enabled }}
+  JIGASI_XMPP_USER: '{{ .Values.jigasi.xmpp.user | b64enc }}'
   JIGASI_XMPP_PASSWORD: '{{ default (randAlphaNum 10) .Values.jigasi.xmpp.password | b64enc }}'
   {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -234,6 +234,45 @@ octo:
   enabled: false
 
 
+jigasi:
+  ## Enabling Jigasi will allow regular SIP clients to join Jitsi meetings
+  ## or nearly real-time transcription.
+  enabled: false
+
+  ## Use external Jigasi installation.
+  ## This setting skips the creation of Jigasi Deployment altogether,
+  ## instead creating just the config secret and enabling services.
+  ## Defaults to disabled (use bundled Jigasi).
+  useExternalJigasi: true
+
+  replicaCount: 1
+  image:
+    repository: jitsi/jigasi
+
+  breweryMuc: jigasibrewery
+
+  ## jigasi XMPP user credentials:
+  xmpp:
+    password:
+
+  livenessProbe:
+    tcpSocket:
+      port: 8788
+  readinessProbe:
+    tcpSocket:
+      port: 8788
+
+  podLabels: {}
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext: {}
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  extraEnvs: {}
+
+
 jibri:
   ## Enabling Jibri will allow users to record
   ## and/or stream their meetings (e.g. to YouTube).
@@ -369,6 +408,8 @@ prosody:
   enabled: true
   server:
   extraEnvFrom:
+  - secretRef:
+      name: '{{ include "prosody.fullname" . }}-jigasi'
   - secretRef:
       name: '{{ include "prosody.fullname" . }}-jicofo'
   - secretRef:

--- a/values.yaml
+++ b/values.yaml
@@ -253,6 +253,7 @@ jigasi:
 
   ## jigasi XMPP user credentials:
   xmpp:
+    user: jigasi
     password:
 
   livenessProbe:


### PR DESCRIPTION
This PR adds `jigasi`.

`jigasi` allows SIP clients to join Jitsi meetings and transciption. No need to publicly open ports if SIP server allows media traffics over itself.

Even some use-cases are tricky as mentioned in [this issue](https://github.com/jitsi-contrib/jitsi-helm/issues/73), there are some other uses-cases which work with simple settings.