### PR TITLE
Enable the jibri secret template by default but data are conditional

### DIFF
--- a/templates/jibri/xmpp-secret.yaml
+++ b/templates/jibri/xmpp-secret.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.jibri.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,6 +6,7 @@ metadata:
     {{- include "jitsi-meet.jibri.labels" . | nindent 4 }}
 type: Opaque
 data:
+{{- if .Values.jibri.enabled }}
   JIBRI_XMPP_USER: '{{ .Values.jibri.xmpp.user | b64enc }}'
   JIBRI_XMPP_PASSWORD: '{{ default (randAlphaNum 10) .Values.jibri.xmpp.password | b64enc }}'
   JIBRI_RECORDER_USER: '{{ .Values.jibri.recorder.user | b64enc }}'

--- a/values.yaml
+++ b/values.yaml
@@ -410,16 +410,15 @@ prosody:
   server:
   extraEnvFrom:
   - secretRef:
-      name: '{{ include "prosody.fullname" . }}-jigasi'
+      name: '{{ include "prosody.fullname" . }}-jibri'
   - secretRef:
       name: '{{ include "prosody.fullname" . }}-jicofo'
+  - secretRef:
+      name: '{{ include "prosody.fullname" . }}-jigasi'
   - secretRef:
       name: '{{ include "prosody.fullname" . }}-jvb'
   - configMapRef:
       name: '{{ include "prosody.fullname" . }}-common'
-  ## Uncomment this if you want to use jibri:
-  # - secretRef:
-  #     name: '{{ include "prosody.fullname" . }}-jibri'
   image:
     repository: jitsi/prosody
     tag: 'stable-9111'


### PR DESCRIPTION
PR applies the same logic used for `jigasi`'s secrets to `jibri`. The template is enabled by default but data are conditional.