### PR TITLE
Upgrade to stable-9364

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -16,9 +16,8 @@ type: application
 # to the chart and its templates, including the app version.
 version: 1.4.0
 
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application.
-appVersion: stable-9111
+# This is the version number of the application being deployed.
+appVersion: stable-9364
 
 dependencies:
   - name: prosody

--- a/charts/prosody/Chart.yaml
+++ b/charts/prosody/Chart.yaml
@@ -16,6 +16,5 @@ type: application
 # to the chart and its templates, including the app version.
 version: 1.4.0
 
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application.
-appVersion: stable-9111
+# This is the version number of the application being deployed.
+appVersion: stable-9364

--- a/values.yaml
+++ b/values.yaml
@@ -485,4 +485,4 @@ prosody:
       _prosody_cfg_lua: ""
       _saslauthd_conf: ""
       _jitsi_meet_cfg_lua: ""
-    tag: 'stable-9111'
+    tag: stable-9364


### PR DESCRIPTION
Upgrades to the latest version, removes redundant comment saying that the `appVersion` should be bumped on every change to the chart (that would likely be the _chart_ version).

I didn't bump the chart version because 1.4.0 has not been released yet.