### PR TITLE
Standardize releaseSecretsOverride for jigasi

### DIFF
--- a/templates/jigasi/deployment.yaml
+++ b/templates/jigasi/deployment.yaml
@@ -48,6 +48,11 @@ spec:
               name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-common
           - configMapRef:
               name: {{ include "jitsi-meet.jigasi.fullname" . }}
+          {{- if .Values.global.releaseSecretsOverride.enabled }}
+          {{- range .Values.global.releaseSecretsOverride.extraEnvFrom }}
+          - {{ tpl (toYaml . ) $ | indent 12 | trim }}
+          {{- end }}
+          {{- end }}
           {{- with .Values.jigasi.livenessProbe }}
           livenessProbe:
           {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
The releaseSecretsOverride is ignored for the jigasi container. This PR fixes that.