### PR TITLE
Include custom interface_config.js

### DIFF
--- a/templates/web/configmap-conffiles.yaml
+++ b/templates/web/configmap-conffiles.yaml
@@ -11,6 +11,12 @@ data:
   {{- else }}
   # Not providing /config/custom-config.js
   {{ end }}
+  custom-interface_config.js: |
+  {{- if .Values.web.custom.configs._custom_interface_config_js }}
+    {{- .Values.web.custom.configs._custom_interface_config_js | nindent 4 }}
+  {{- else }}
+  # Not providing /config/custom-interface_config.js
+  {{ end }}
   default: |
   {{- if .Values.web.custom.defaults._default }}
     {{- .Values.web.custom.defaults._default | nindent 4 }}

--- a/templates/web/deployment.yaml
+++ b/templates/web/deployment.yaml
@@ -79,6 +79,11 @@ spec:
             mountPath: /config/custom-config.js
             subPath: custom-config.js
           {{- end }}
+          {{- if .Values.web.custom.configs._custom_interface_config_js }}
+          - name: custom-conffiles
+            mountPath: /config/custom-interface_config.js
+            subPath: custom-interface_config.js
+          {{- end }}
           {{- if .Values.web.custom.defaults._default }}
           - name: custom-conffiles
             mountPath: /defaults/default
@@ -151,6 +156,8 @@ spec:
           items:
             - key: custom-config.js
               path: custom-config.js
+            - key: custom-interface_config.js
+              path: custom-interface_config.js
             - key: default
               path: default
             - key: ffdhe2048.txt

--- a/values.yaml
+++ b/values.yaml
@@ -70,6 +70,7 @@ web:
       _ssl_conf: ""
       _system_config_js: ""
     configs:
+      _custom_interface_config_js: ""
       _custom_config_js: ""
 
   extraEnvs: {}


### PR DESCRIPTION
This minor change enables users to provide custom-interface_config.js values via the helm chart in a similar manner to custom-config.js values.  While interface_config.js is slated to go away, there are still options that can only be configured via it, so this will likely help others too.