### PR TITLE
jvb: allow to specify jvb service's ipFamilyPolicy

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ Parameter | Description | Default
 `jvb.stunServers` | List of STUN/TURN servers to announce to the users | `meet-jit-si-turnrelay.jitsi.net:443`
 `jvb.service.enabled` | Boolean to enable os disable the jvb service creation | `false` if `jvb.useHostPort` is `true` otherwise `true`
 `jvb.service.type` | Type of the jvb service | `ClusterIP`
+`jvb.service.ipFamilyPolicy` | `ipFamilyPolicy` for the service ([docs](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services)) | `(unset)`
 `jvb.service.annotations` | Additional annotations for JVB service (might be useful for managed k8s) | `{}`
 `jvb.service.extraPorts` | Additional ports to expose from your JVB pod(s) | `[]`
 `jvb.UDPPort` | UDP port used by jvb, also affects port of service, and hostPort | `10000`

--- a/templates/jvb/service.yaml
+++ b/templates/jvb/service.yaml
@@ -14,6 +14,9 @@ spec:
   {{- with .Values.jvb.service.loadBalancerIP }}
   loadBalancerIP: {{ . }}
   {{- end }}
+  {{- with .Values.jvb.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
   ports:
     - port: {{ default 10000 .Values.jvb.UDPPort }}
       {{- if and .Values.jvb.nodePort (or (eq .Values.jvb.service.type "NodePort") (eq .Values.jvb.service.type "LoadBalancer")) }}

--- a/values.yaml
+++ b/values.yaml
@@ -233,6 +233,9 @@ jvb:
     type: ClusterIP
     externalTrafficPolicy: Cluster
     externalIPs: []
+    ## If type is set to LoadBalancer and the cluster is dual stack, ipFamilyPolicy can be set to enable dual stack
+    # addressing for the service.
+    # ipFamilyPolicy: PreferDualStack
     ## Annotations to be added to the service (if LoadBalancer is used)
     #  An example below is needed for DigitalOcean managed k8s setups
     #  with a LoadBalancer service, so that DO's external LB can perform


### PR DESCRIPTION
Services with type `LoadBalancer` on dual stack clusters require this field in order to be assigned a v6 address: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#service-type-loadbalancer