### PR TITLE
fix indent extraVolume in web deployment

### DIFF
--- a/templates/web/deployment.yaml
+++ b/templates/web/deployment.yaml
@@ -175,5 +175,5 @@ spec:
             - key: system-config.js
               path: system-config.js
     {{- with .Values.web.extraVolumes }}
-        {{- toYaml . | nindent 8 }}
+      {{- toYaml . | nindent 6 }}
     {{- end }}


### PR DESCRIPTION
Wrong indentation in file templates/web/deployment.yaml

fixing following error : 
`Error: UPGRADE FAILED: YAML parse error on jitsi-meet/templates/web/deployment.yaml: error converting YAML to JSON: yaml: line 97: did not find expected key`