### PR TITLE
Jigasi change probes to httpGet

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -326,11 +326,19 @@ jigasi:
     password:
 
   livenessProbe:
-    tcpSocket:
+    httpGet:
+      path: /about/health
       port: 8788
+      httpHeaders:
+        - name: Accept
+          value: application/json
   readinessProbe:
-    tcpSocket:
+    httpGet:
+      path: /about/health
       port: 8788
+      httpHeaders:
+        - name: Accept
+          value: application/json
 
   podLabels: {}
   podAnnotations: {}


### PR DESCRIPTION
This implements the changes discussed in: #146
We can still add the tcp probe as a startupProbe, but in our deployment that was not necessary.