### PR TITLE
Add options to provide XMPP credentials as external secrets

### DIFF
--- a/templates/jibri/deployment.yaml
+++ b/templates/jibri/deployment.yaml
@@ -58,8 +58,20 @@ spec:
         {{- end }}
 
         envFrom:
+        {{ if .Values.global.jibri.xmpp.secret }}
+        - secretRef:
+            name: {{ .Values.global.jibri.xmpp.secret }}
+        {{ end }}
+        {{ if .Values.global.jibri.recorder.secret }}
+        - secretRef:
+            name: {{ .Values.global.jibri.recorder.secret }}
+        {{ end }}
+        {{ if not (or .Values.global.jibri.xmpp.secret .Values.jibri.recorder.secret) }}
         - secretRef:
             name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-jibri
+        - secretRef:
+            name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-recorder
+        {{ end }}
         - configMapRef:
             name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-common
         - configMapRef:

--- a/templates/jibri/xmpp-secret.yaml
+++ b/templates/jibri/xmpp-secret.yaml
@@ -1,3 +1,5 @@
+{{- if not .Values.global.jibri.xmpp.secret }}
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,8 +9,24 @@ metadata:
 type: Opaque
 data:
 {{- if .Values.jibri.enabled }}
-  JIBRI_XMPP_USER: '{{ .Values.jibri.xmpp.user | b64enc }}'
-  JIBRI_XMPP_PASSWORD: '{{ default (randAlphaNum 10) .Values.jibri.xmpp.password | b64enc }}'
-  JIBRI_RECORDER_USER: '{{ .Values.jibri.recorder.user | b64enc }}'
-  JIBRI_RECORDER_PASSWORD: '{{ default (randAlphaNum 10) .Values.jibri.recorder.password | b64enc }}'
+  JIBRI_XMPP_USER: '{{ .Values.global.jibri.xmpp.user | b64enc }}'
+  JIBRI_XMPP_PASSWORD: '{{ default (randAlphaNum 10) .Values.global.jibri.xmpp.password | b64enc }}'
+...
+{{- end }}
+{{- end }}
+{{- if not .Values.global.jibri.recorder.secret }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-recorder
+  labels:
+    {{- include "jitsi-meet.jibri.labels" . | nindent 4 }}
+type: Opaque
+data:
+{{- if .Values.jibri.enabled }}
+  JIBRI_RECORDER_USER: '{{ .Values.global.jibri.recorder.user | b64enc }}'
+  JIBRI_RECORDER_PASSWORD: '{{ default (randAlphaNum 10) .Values.global.jibri.recorder.password | b64enc }}'
+{{- end }}
+...
 {{- end }}

--- a/templates/jicofo/deployment.yaml
+++ b/templates/jicofo/deployment.yaml
@@ -59,8 +59,13 @@ spec:
           image: "{{ .Values.jicofo.image.repository }}:{{ default .Chart.AppVersion .Values.jicofo.image.tag }}"
           imagePullPolicy: {{ pluck "pullPolicy" .Values.jicofo.image .Values.image | first }}
           envFrom:
+          {{ if .Values.global.jicofo.xmpp.secret }}
+          - secretRef:
+              name: {{ .Values.global.jicofo.xmpp.secret }}
+          {{ else }}
           - secretRef:
               name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-jicofo
+          {{ end }}
           - configMapRef:
               name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-common
           - configMapRef:

--- a/templates/jicofo/xmpp-secret.yaml
+++ b/templates/jicofo/xmpp-secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.global.jicofo.xmpp.secret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,5 +8,6 @@ metadata:
 type: Opaque
 data:
   JICOFO_AUTH_USER: '{{ b64enc "focus" }}'
-  JICOFO_AUTH_PASSWORD: '{{ default (randAlphaNum 10) .Values.jicofo.xmpp.password | b64enc }}'
-  JICOFO_COMPONENT_SECRET: '{{ default (randAlphaNum 10) .Values.jicofo.xmpp.componentSecret | b64enc }}'
+  JICOFO_AUTH_PASSWORD: '{{ default (randAlphaNum 10) .Values.global.jicofo.xmpp.password | b64enc }}'
+  JICOFO_COMPONENT_SECRET: '{{ default (randAlphaNum 10) .Values.global.jicofo.xmpp.componentSecret | b64enc }}'
+{{- end }}

--- a/templates/jigasi/deployment.yaml
+++ b/templates/jigasi/deployment.yaml
@@ -42,8 +42,13 @@ spec:
           image: "{{ .Values.jigasi.image.repository }}:{{ default .Chart.AppVersion .Values.jigasi.image.tag }}"
           imagePullPolicy: {{ pluck "pullPolicy" .Values.jigasi.image .Values.image | first }}
           envFrom:
+          {{- if .Values.global.jigasi.xmpp.secret }}
+          - secretRef:
+              name: {{ .Values.jigasi.secret }}
+          {{- else }}
           - secretRef:
               name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-jigasi
+          {{- end }}
           - configMapRef:
               name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-common
           - configMapRef:

--- a/templates/jigasi/xmpp-secret.yaml
+++ b/templates/jigasi/xmpp-secret.yaml
@@ -1,3 +1,4 @@
+{{ if not .Values.global.jigasi.xmpp.secret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,6 +8,7 @@ metadata:
 type: Opaque
 data:
   {{- if .Values.jigasi.enabled }}
-  JIGASI_XMPP_USER: '{{ .Values.jigasi.xmpp.user | b64enc }}'
-  JIGASI_XMPP_PASSWORD: '{{ default (randAlphaNum 10) .Values.jigasi.xmpp.password | b64enc }}'
+  JIGASI_XMPP_USER: '{{ .Values.global.jigasi.xmpp.user | b64enc }}'
+  JIGASI_XMPP_PASSWORD: '{{ default (randAlphaNum 10) .Values.global.jigasi.xmpp.password | b64enc }}'
   {{- end }}
+{{- end }}

--- a/templates/jvb/deployment.yaml
+++ b/templates/jvb/deployment.yaml
@@ -54,7 +54,7 @@ spec:
           imagePullPolicy: {{ pluck "pullPolicy" .Values.jvb.image .Values.image | first }}
           envFrom:
           - secretRef:
-              name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-jvb
+              name: {{ coalesce .Values.global.jvb.xmpp.secret (printf "%s-%s" (include "call-nested" (list . "prosody" "prosody.fullname")) "jvb") }}
           - configMapRef:
               name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-common
           - configMapRef:

--- a/templates/jvb/xmpp-secret.yaml
+++ b/templates/jvb/xmpp-secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.global.jvb.xmpp.secret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,5 +7,6 @@ metadata:
     {{- include "jitsi-meet.jvb.labels" . | nindent 4 }}
 type: Opaque
 data:
-  JVB_AUTH_USER: '{{ .Values.jvb.xmpp.user | b64enc }}'
-  JVB_AUTH_PASSWORD: '{{ default (randAlphaNum 10) .Values.jvb.xmpp.password | b64enc }}'
+  JVB_AUTH_USER: '{{ .Values.global.jvb.xmpp.user | b64enc }}'
+  JVB_AUTH_PASSWORD: '{{ default (randAlphaNum 10) .Values.global.jvb.xmpp.password | b64enc }}'
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -17,6 +17,41 @@ global:
     #      name: '{{ include "prosody.fullname" . }}-overrides'
     #      optional: true
 
+  jibri:
+    ## jibri XMPP user credentials:
+    xmpp:
+      user: jibri
+      password:
+      ## Alternatively provide a name for an externally managed secret containing the values for JIBRI_XMPP_USER and JIBRI_XMPP_PASSWORD
+      secret:
+    ## recorder XMPP user credentials:
+    recorder:
+      user: recorder
+      password:
+      ## Alternatively provide a name for an externally managed secret containing the values for JIBRI_RECORDER_USER and JIBRI_RECORDER_PASSWORD
+      secret:
+  jicofo:
+    ## jicofo XMPP user credentials:
+    xmpp:
+      password:
+      componentSecret:
+      ## Alternatively provide a name for an externally managed secret containing the values for JICOFO_XMPP_USER, JICOFO_AUTH_PASSWORD, JICOFO_COMPONENT_SECRET
+      secret:
+  jigasi:
+    ## jigasi XMPP user credentials:
+    xmpp:
+      user: jigasi
+      password:
+      ## Alternatively provide a name for an externally managed secret containing the values for JIGASI_XMPP_USER and JIGASI_AUTH_PASSWORD
+      secret:
+  jvb:
+    ## jvb XMPP user credentials:
+    xmpp:
+      user: jvb
+      password:
+      ## Alternatively provide a name for an externally managed secret containing the values for JVB_AUTH_USER, JVB_AUTH_PASSWORD, JICOFO_COMPONENT_SECRET
+      secret:
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
@@ -166,10 +201,6 @@ jicofo:
       _jicofo_conf: ""
       _logging_properties: ""
 
-  xmpp:
-    password:
-    componentSecret:
-
   livenessProbe:
     tcpSocket:
       port: 8888
@@ -199,10 +230,6 @@ jvb:
   replicaCount: 1
   image:
     repository: jitsi/jvb
-
-  xmpp:
-    user: jvb
-    password:
 
   ## Set public IP addresses to be advertised by JVB.
   #  You can specify your nodes' IP addresses,
@@ -327,11 +354,6 @@ jigasi:
 
   breweryMuc: jigasibrewery
 
-  ## jigasi XMPP user credentials:
-  xmpp:
-    user: jigasi
-    password:
-
   livenessProbe:
     httpGet:
       path: /about/health
@@ -434,15 +456,6 @@ jibri:
   breweryMuc: jibribrewery
   timeout: 90
 
-  ## jibri XMPP user credentials:
-  xmpp:
-    user: jibri
-    password:
-
-  ## recorder XMPP user credentials:
-  recorder:
-    user: recorder
-    password:
 
   livenessProbe:
     initialDelaySeconds: 5
@@ -513,13 +526,15 @@ prosody:
   server:
   extraEnvFrom:
   - secretRef:
-      name: '{{ include "prosody.fullname" . }}-jibri'
+      name: '{{ .Values.global.jibri.xmpp.secret | default (printf "%s-%s" (include "prosody.fullname" .) "jibri") }}'
   - secretRef:
-      name: '{{ include "prosody.fullname" . }}-jicofo'
+      name: '{{ .Values.global.jibri.recorder.secret | default (printf "%s-%s" (include "prosody.fullname" .) "recorder") }}'
   - secretRef:
-      name: '{{ include "prosody.fullname" . }}-jigasi'
+      name: '{{ .Values.global.jicofo.xmpp.secret | default (printf "%s-%s" (include "prosody.fullname" .) "jicofo") }}'
   - secretRef:
-      name: '{{ include "prosody.fullname" . }}-jvb'
+      name: '{{ .Values.global.jigasi.xmpp.secret | default (printf "%s-%s" (include "prosody.fullname" .) "jigasi") }}'
+  - secretRef:
+      name: '{{ .Values.global.jvb.xmpp.secret | default (printf "%s-%s" (include "prosody.fullname" .) "jvb") }}'
   - configMapRef:
       name: '{{ include "prosody.fullname" . }}-common'
   image:


### PR DESCRIPTION
Allows to use XMPP credentials from existing secrets. This should enable the use of Kubernetes secret managers. See #158 for context. 

To this end there was the need to make some changes to the structure of the Helm-chart

* Move the XMPP credentials in `values.yaml` from the scope of each component to the global scope.
* Split the XMPP-secret of the Jigasi component, such that the recorder credentials and the Jigasi credentials can be provided by distinct secrets.