### PR TITLE
Add jicofo and jibri Metrics exporter

### DIFF
--- a/files/grafana_dashboards/jitsi-jicofo.json
+++ b/files/grafana_dashboards/jitsi-jicofo.json
@@ -1,0 +1,106 @@
+{
+  "__inputs": [],
+  "__requires": [],
+  "annotations": {
+    "list": []
+  },
+  "panels": [
+    {
+      "title": "XMPP Traffic",
+      "type": "timeseries",
+      "targets": [
+        {"expr": "jitsi_xmpp_service_total_recv", "legendFormat": "Received"},
+        {"expr": "jitsi_xmpp_service_total_sent", "legendFormat": "Sent"}
+      ],
+      "gridPos": {"x": 0, "y": 0, "w": 12, "h": 8}
+    },
+    {
+      "title": "Jibri Availability",
+      "type": "stat",
+      "targets": [
+        {"expr": "jitsi_jibri_count", "legendFormat": "Total Jibris"},
+        {"expr": "jitsi_jibri_available", "legendFormat": "Available"}
+      ],
+      "gridPos": {"x": 12, "y": 0, "w": 12, "h": 8}
+    },
+    {
+      "title": "Conference Size Stats",
+      "type": "stat",
+      "targets": [
+        {"expr": "jitsi_conference_sizes_average", "legendFormat": "Average"},
+        {"expr": "jitsi_conference_sizes_max", "legendFormat": "Max"},
+        {"expr": "jitsi_conference_sizes_min", "legendFormat": "Min"}
+      ],
+      "gridPos": {"x": 0, "y": 8, "w": 12, "h": 8}
+    },
+    {
+      "title": "Conferences & Participants",
+      "type": "timeseries",
+      "targets": [
+        {"expr": "jitsi_total_conferences_created", "legendFormat": "Total Conferences"},
+        {"expr": "jitsi_total_participants", "legendFormat": "Total Participants"},
+        {"expr": "jitsi_conferences", "legendFormat": "Current Conferences"},
+        {"expr": "jitsi_participants", "legendFormat": "Current Participants"}
+      ],
+      "gridPos": {"x": 12, "y": 8, "w": 12, "h": 8}
+    },
+    {
+      "title": "Jicofo Performance",
+      "type": "stat",
+      "targets": [
+        {"expr": "jitsi_jicofo_threads", "legendFormat": "Threads"},
+        {"expr": "jitsi_jicofo_largest_conferences", "legendFormat": "Largest Conference"}
+      ],
+      "gridPos": {"x": 0, "y": 16, "w": 12, "h": 8}
+    },
+    {
+      "title": "Bridge Health",
+      "type": "stat",
+      "targets": [
+        {"expr": "jitsi_bridge_count", "legendFormat": "Total Bridges"},
+        {"expr": "jitsi_operational_bridge_count", "legendFormat": "Operational"},
+        {"expr": "jitsi_bridge_selector_lost_bridges", "legendFormat": "Lost Bridges"}
+      ],
+      "gridPos": {"x": 12, "y": 16, "w": 12, "h": 8}
+    },
+    {
+      "title": "Bridge Load & Failover Stats",
+      "type": "timeseries",
+      "targets": [
+        {"expr": "jitsi_bridge_selector_total_least_loaded_in_region", "legendFormat": "Least Loaded (Region)"},
+        {"expr": "jitsi_bridge_selector_total_split_due_to_load", "legendFormat": "Split Due to Load"},
+        {"expr": "jitsi_bridge_selector_total_not_loaded_in_region", "legendFormat": "Not Loaded (Region)"},
+        {"expr": "jitsi_bridge_selector_in_shutdown_bridge_count", "legendFormat": "In Shutdown"}
+      ],
+      "gridPos": {"x": 0, "y": 24, "w": 24, "h": 8}
+    },
+    {
+      "title": "Jibri Recording & SIP Status",
+      "type": "stat",
+      "targets": [
+        {"expr": "jitsi_recording_active", "legendFormat": "Active Recordings"},
+        {"expr": "jitsi_recording_pending", "legendFormat": "Pending Recordings"},
+        {"expr": "jitsi_sip_call_active", "legendFormat": "Active SIP Calls"},
+        {"expr": "jitsi_sip_call_pending", "legendFormat": "Pending SIP Calls"}
+      ],
+      "gridPos": {"x": 0, "y": 32, "w": 24, "h": 8}
+    },
+    {
+      "title": "Failures Overview",
+      "type": "stat",
+      "targets": [
+        {"expr": "jitsi_total_sip_call_failures", "legendFormat": "SIP Call Failures"},
+        {"expr": "jitsi_total_live_streaming_failures", "legendFormat": "Live Streaming Failures"},
+        {"expr": "jitsi_total_recording_failures", "legendFormat": "Recording Failures"},
+        {"expr": "jitsi_participants_notification_ice_failed", "legendFormat": "ICE Failures"},
+        {"expr": "jitsi_participants_notification_request_restart", "legendFormat": "ICE Restarts"}
+      ],
+      "gridPos": {"x": 0, "y": 40, "w": 24, "h": 8}
+    }
+  ],
+  "title": "Jitsi jicofo Full Metrics",
+  "timezone": "browser",
+  "schemaVersion": 30,
+  "version": 1,
+  "refresh": "10s"
+}

--- a/templates/jibri/deployment.yaml
+++ b/templates/jibri/deployment.yaml
@@ -37,6 +37,20 @@ spec:
     {{- end }}
       serviceAccountName: {{ include "jitsi-meet.serviceAccountName" . }}
       containers:
+      {{- if .Values.jibri.metrics.enabled }}
+      - name: metrics
+        image: {{ .Values.jibri.metrics.image.repository }}:{{ .Values.jibri.metrics.image.tag }}
+        imagePullPolicy: {{ .Values.jibri.metrics.image.pullPolicy }}
+        securityContext:
+          runAsUser: 10001
+        args:
+          - "-jibri-status-url=http://localhost:2222/jibri/api/v1.0/health"
+        ports:
+          - containerPort: 9889
+            name: tcp-metrics
+        resources:
+      {{- toYaml .Values.jibri.metrics.resources | nindent 12 }}      
+      {{- end }}        
       - name: {{ .Chart.Name }}
         securityContext:
           capabilities:

--- a/templates/jibri/metrics-prometheus.yaml
+++ b/templates/jibri/metrics-prometheus.yaml
@@ -1,0 +1,31 @@
+{{- if and (.Values.jibri.metrics.enabled) (.Values.jibri.metrics.serviceMonitor.enabled) }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ template "jitsi-meet.jibri.fullname" . }}
+  labels:
+    {{- include "jitsi-meet.jibri.labels" . | nindent 4 }}
+    {{- with .Values.jibri.metrics.serviceMonitor.selector }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  podMetricsEndpoints:
+    - port: tcp-metrics
+      path: /metrics
+      interval: 15s
+      {{- with .Values.jibri.metrics.serviceMonitor.honorLabels }}
+      honorLabels: {{ . }}
+      {{- end }}
+      {{- with .Values.jibri.metrics.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+  selector:
+    matchLabels:
+        {{- include "jitsi-meet.jibri.selectorLabels" . | nindent 8 }}
+      {{- range $label, $value := mergeOverwrite .Values.global.podLabels .Values.jibri.podLabels }}
+        {{ $label }}: {{ $value }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  {{- end -}}

--- a/templates/jicofo/deployment.yaml
+++ b/templates/jicofo/deployment.yaml
@@ -53,6 +53,20 @@ spec:
             - key: logging.properties
               path: logging.properties
       containers:
+      {{- if .Values.jicofo.metrics.enabled }}
+        - name: metrics
+          image: {{ .Values.jicofo.metrics.image.repository }}:{{ .Values.jicofo.metrics.image.tag }}
+          imagePullPolicy: {{ .Values.jicofo.metrics.image.pullPolicy }}
+          securityContext:
+            runAsUser: 10001
+          args:
+            - "--jicofo.scrape-uri=http://localhost:8888/stats"
+          ports:
+            - containerPort: 9996
+              name: tcp-metrics
+          resources:
+        {{- toYaml .Values.jicofo.metrics.resources | nindent 12 }}      
+      {{- end }}       
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.jicofo.securityContext | nindent 12 }}

--- a/templates/jicofo/metrics-prometheus.yaml
+++ b/templates/jicofo/metrics-prometheus.yaml
@@ -1,0 +1,27 @@
+{{- if and (.Values.jicofo.metrics.enabled) (.Values.jicofo.metrics.serviceMonitor.enabled) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "jitsi-meet.jicofo.fullname" . }}
+  labels:
+    {{- include "jitsi-meet.jicofo.labels" . | nindent 4 }}
+    {{- with .Values.jicofo.metrics.serviceMonitor.selector }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: tcp-metrics
+      path: /metrics
+      {{- with .Values.jicofo.metrics.serviceMonitor.honorLabels }}
+      honorLabels: {{ . }}
+      {{- end }}
+      {{- with .Values.jicofo.metrics.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+  selector:
+    matchLabels:
+      {{- include "jitsi-meet.jicofo.labels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  {{- end -}}

--- a/templates/jicofo/metrics-service.yaml
+++ b/templates/jicofo/metrics-service.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.jicofo.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "jitsi-meet.jicofo.fullname" . }}-metrics
+  labels:
+  {{- include "jitsi-meet.jicofo.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: tcp-metrics
+      port: 9996
+      targetPort: 9996
+  selector:
+  {{- include "jitsi-meet.jicofo.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -178,6 +178,29 @@ jicofo:
     tcpSocket:
       port: 8888
 
+  metrics:
+    enabled: true
+    image:
+      repository: prayagsingh/prometheus-jicofo-exporter
+      tag: latest
+      pullPolicy: IfNotPresent
+
+    resources:
+      requests:
+        cpu: 10m
+        memory: 20Mi
+      limits:
+        cpu: 20m
+        memory: 40Mi
+
+    prometheusAnnotations: true
+    serviceMonitor:
+      enabled: true
+      selector:
+        release: prometheus-operator
+      interval: 10s
+      # honorLabels: false 
+
   podLabels: {}
   podAnnotations: {}
   podSecurityContext: {}
@@ -469,6 +492,29 @@ jibri:
           curl -sq localhost:2222/jibri/api/v1.0/health
           | jq '"\(.status.health.healthStatus) \(.status.busyStatus)"'
           | grep -qP 'HEALTHY (IDLE|BUSY)'
+
+  metrics:
+    enabled: true
+    image:
+      repository: prayagsingh/prometheus-jibri-exporter
+      tag: latest
+      pullPolicy: IfNotPresent
+
+    resources:
+      requests:
+        cpu: 60m
+        memory: 100Mi
+      limits:
+        cpu: 90m
+        memory: 120Mi
+
+    prometheusAnnotations: true
+    serviceMonitor:
+      enabled: true
+      selector:
+        release: prometheus-operator
+      interval: 10s
+      # honorLabels: false
 
   nodeSelector: {}
   tolerations: []


### PR DESCRIPTION
This PR enhances the Helm chart by adding support for Jitsi-related metrics and monitoring. The changes include:

➕ PodMonitor for Jibri pods: Enables Prometheus to scrape metrics from each Jibri instance individually.

📊 Jicofo metrics integration: Added support to expose and collect metrics from Jicofo via [prometheus-jicofo-exporter](https://github.com/prayagsingh/prometheus-jicofo-exporter) & [prometheus-jibri-exporter](https://github.com/prayagsingh/prometheus-jibri-exporter).

⚙️ Metrics configuration in values.yaml: Users can now enable and customize metrics exporters directly through chart values.

📈 Basic Grafana dashboard for Jicofo: Provides an out-of-the-box dashboard to visualize Jicofo metrics.

These additions make it easier to monitor Jitsi components and gain insights into system performance and behavior.