### PR TITLE
Add annotations support web service

### DIFF
--- a/templates/web/service.yaml
+++ b/templates/web/service.yaml
@@ -2,6 +2,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "jitsi-meet.web.fullname" . }}
+  annotations:
+  {{- range $key, $value := .Values.web.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+
   labels:
     {{- include "jitsi-meet.web.labels" . | nindent 4 }}
 spec:

--- a/values.yaml
+++ b/values.yaml
@@ -84,6 +84,10 @@ web:
     # nodePort: 30580
     # port: 80
     externalIPs: []
+    ## Annotations to be added to the service (if LoadBalancer is used)
+    #  An example below is needed for GKE IAP enablement
+    annotations: {}
+      # beta.cloud.google.com/backend-config: backend-config-iap
 
   ingress:
     enabled: false


### PR DESCRIPTION
This PR enhances the Helm chart by adding support of annotations to the service of web component. 

