### PR TITLE
Allow using existing secrets for jitsi components

### DIFF
--- a/templates/jibri/_helper.tpl
+++ b/templates/jibri/_helper.tpl
@@ -14,5 +14,5 @@ app.kubernetes.io/component: jibri
 {{- end -}}
 
 {{- define "jitsi-meet.jibri.secret" -}}
-{{ include "call-nested" (list . "prosody" "prosody.fullname") }}-jibri
+{{- default (printf "%s-jibri" (include "call-nested" (list . "prosody" "prosody.fullname"))) .Values.jibri.existingSecret -}}
 {{- end -}}

--- a/templates/jibri/deployment.yaml
+++ b/templates/jibri/deployment.yaml
@@ -26,7 +26,9 @@ spec:
       {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/jibri/configmap.yaml") . | sha256sum }}
+        {{- if empty .Values.jibri.existingSecret }}
         checksum/secret: {{ include (print $.Template.BasePath "/jibri/xmpp-secret.yaml") . | sha256sum }}
+        {{- end }}
       {{- range $annotation, $value := mergeOverwrite .Values.global.podAnnotations .Values.jibri.podAnnotations }}
         {{ $annotation }}: {{ $value | quote }}
       {{- end }}
@@ -59,7 +61,7 @@ spec:
 
         envFrom:
         - secretRef:
-            name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-jibri
+            name: {{ include "jitsi-meet.jibri.secret" . }}
         - configMapRef:
             name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-common
         - configMapRef:

--- a/templates/jibri/xmpp-secret.yaml
+++ b/templates/jibri/xmpp-secret.yaml
@@ -1,14 +1,16 @@
+{{- if empty .Values.jibri.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-jibri
+  name: {{ include "jitsi-meet.jibri.secret" . }}
   labels:
     {{- include "jitsi-meet.jibri.labels" . | nindent 4 }}
 type: Opaque
 data:
-{{- if .Values.jibri.enabled }}
+  {{- if .Values.jibri.enabled }}
   JIBRI_XMPP_USER: '{{ .Values.jibri.xmpp.user | b64enc }}'
   JIBRI_XMPP_PASSWORD: '{{ default (randAlphaNum 10) .Values.jibri.xmpp.password | b64enc }}'
   JIBRI_RECORDER_USER: '{{ .Values.jibri.recorder.user | b64enc }}'
   JIBRI_RECORDER_PASSWORD: '{{ default (randAlphaNum 10) .Values.jibri.recorder.password | b64enc }}'
+  {{- end }}
 {{- end }}

--- a/templates/jicofo/_helper.tpl
+++ b/templates/jicofo/_helper.tpl
@@ -14,5 +14,5 @@ app.kubernetes.io/component: jicofo
 {{- end -}}
 
 {{- define "jitsi-meet.jicofo.secret" -}}
-{{ include "call-nested" (list . "prosody" "prosody.fullname") }}-jicofo
+{{- default (printf "%s-jicofo" (include "call-nested" (list . "prosody" "prosody.fullname"))) .Values.jicofo.existingSecret -}}
 {{- end -}}

--- a/templates/jicofo/deployment.yaml
+++ b/templates/jicofo/deployment.yaml
@@ -22,7 +22,9 @@ spec:
       {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/jicofo/configmap.yaml") . | sha256sum }}
+        {{- if empty .Values.jicofo.existingSecret }}
         checksum/secret: {{ include (print $.Template.BasePath "/jicofo/xmpp-secret.yaml") . | sha256sum }}
+        {{- end }}
       {{- range $annotation, $value := mergeOverwrite .Values.global.podAnnotations .Values.jicofo.podAnnotations }}
         {{ $annotation }}: {{ $value | quote }}
       {{- end }}
@@ -60,7 +62,7 @@ spec:
           imagePullPolicy: {{ pluck "pullPolicy" .Values.jicofo.image .Values.image | first }}
           envFrom:
           - secretRef:
-              name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-jicofo
+              name: {{ include "jitsi-meet.jicofo.secret" . }}
           - configMapRef:
               name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-common
           - configMapRef:

--- a/templates/jicofo/xmpp-secret.yaml
+++ b/templates/jicofo/xmpp-secret.yaml
@@ -1,7 +1,8 @@
+{{- if empty .Values.jicofo.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-jicofo
+  name: {{ include "jitsi-meet.jicofo.secret" . }}
   labels:
     {{- include "jitsi-meet.jicofo.labels" . | nindent 4 }}
 type: Opaque
@@ -9,3 +10,4 @@ data:
   JICOFO_AUTH_USER: '{{ b64enc "focus" }}'
   JICOFO_AUTH_PASSWORD: '{{ default (randAlphaNum 10) .Values.jicofo.xmpp.password | b64enc }}'
   JICOFO_COMPONENT_SECRET: '{{ default (randAlphaNum 10) .Values.jicofo.xmpp.componentSecret | b64enc }}'
+{{- end }}

--- a/templates/jigasi/_helper.tpl
+++ b/templates/jigasi/_helper.tpl
@@ -14,5 +14,5 @@ app.kubernetes.io/component: jigasi
 {{- end -}}
 
 {{- define "jitsi-meet.jigasi.secret" -}}
-{{ include "call-nested" (list . "prosody" "prosody.fullname") }}-jigasi
+{{- default (printf "%s-jigasi" (include "call-nested" (list . "prosody" "prosody.fullname"))) .Values.jigasi.existingSecret -}}
 {{- end -}}

--- a/templates/jigasi/deployment.yaml
+++ b/templates/jigasi/deployment.yaml
@@ -23,7 +23,9 @@ spec:
       {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/jigasi/configmap.yaml") . | sha256sum }}
+        {{- if empty .Values.jibri.existingSecret }}
         checksum/secret: {{ include (print $.Template.BasePath "/jigasi/xmpp-secret.yaml") . | sha256sum }}
+        {{- end }}
       {{- range $annotation, $value := mergeOverwrite .Values.global.podAnnotations .Values.jigasi.podAnnotations }}
         {{ $annotation }}: {{ $value | quote }}
       {{- end }}
@@ -55,7 +57,7 @@ spec:
           imagePullPolicy: {{ pluck "pullPolicy" .Values.jigasi.image .Values.image | first }}
           envFrom:
           - secretRef:
-              name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-jigasi
+              name: {{ include "jitsi-meet.jigasi.secret" . }}
           - configMapRef:
               name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-common
           - configMapRef:

--- a/templates/jigasi/xmpp-secret.yaml
+++ b/templates/jigasi/xmpp-secret.yaml
@@ -1,7 +1,8 @@
+{{- if empty .Values.jigasi.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-jigasi
+  name: {{ include "jitsi-meet.jigasi.secret" . }}
   labels:
     {{- include "jitsi-meet.jigasi.labels" . | nindent 4 }}
 type: Opaque
@@ -10,3 +11,4 @@ data:
   JIGASI_XMPP_USER: '{{ .Values.jigasi.xmpp.user | b64enc }}'
   JIGASI_XMPP_PASSWORD: '{{ default (randAlphaNum 10) .Values.jigasi.xmpp.password | b64enc }}'
   {{- end }}
+{{- end }}

--- a/templates/jvb/_helper.tpl
+++ b/templates/jvb/_helper.tpl
@@ -14,5 +14,5 @@ app.kubernetes.io/component: jvb
 {{- end -}}
 
 {{- define "jitsi-meet.jvb.secret" -}}
-{{ include "call-nested" (list . "prosody" "prosody.fullname") }}-jvb
+{{- default (printf "%s-jvb" (include "call-nested" (list . "prosody" "prosody.fullname"))) .Values.jvb.existingSecret -}}
 {{- end -}}

--- a/templates/jvb/deployment.yaml
+++ b/templates/jvb/deployment.yaml
@@ -26,7 +26,9 @@ spec:
       {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/jvb/configmap.yaml") . | sha256sum }}
+        {{- if empty .Values.jvb.existingSecret }}
         checksum/secret: {{ include (print $.Template.BasePath "/jvb/xmpp-secret.yaml") . | sha256sum }}
+        {{- end }}
         {{- if and .Values.jvb.metrics.enabled  .Values.jvb.metrics.prometheusAnnotations  }}
         prometheus.io/port: "9888"
         prometheus.io/scrape: "true"
@@ -54,7 +56,7 @@ spec:
           imagePullPolicy: {{ pluck "pullPolicy" .Values.jvb.image .Values.image | first }}
           envFrom:
           - secretRef:
-              name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-jvb
+              name: {{ include "jitsi-meet.jvb.secret" . }}
           - configMapRef:
               name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-common
           - configMapRef:

--- a/templates/jvb/xmpp-secret.yaml
+++ b/templates/jvb/xmpp-secret.yaml
@@ -1,10 +1,12 @@
+{{- if empty .Values.jvb.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-jvb
+  name: {{ include "jitsi-meet.jvb.secret" . }}
   labels:
     {{- include "jitsi-meet.jvb.labels" . | nindent 4 }}
 type: Opaque
 data:
   JVB_AUTH_USER: '{{ .Values.jvb.xmpp.user | b64enc }}'
   JVB_AUTH_PASSWORD: '{{ default (randAlphaNum 10) .Values.jvb.xmpp.password | b64enc }}'
+{{- end }}

--- a/templates/transcriber/_helper.tpl
+++ b/templates/transcriber/_helper.tpl
@@ -14,5 +14,5 @@ app.kubernetes.io/component: transcriber
 {{- end -}}
 
 {{- define "jitsi-meet.transcriber.secret" -}}
-{{ include "call-nested" (list . "prosody" "prosody.fullname") }}-transcriber
+{{- default (printf "%s-transcriber" (include "call-nested" (list . "prosody" "prosody.fullname"))) .Values.transcriber.existingSecret -}}
 {{- end -}}

--- a/templates/transcriber/deployment.yaml
+++ b/templates/transcriber/deployment.yaml
@@ -23,7 +23,9 @@ spec:
       {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/transcriber/configmap.yaml") . | sha256sum }}
+        {{- if empty .Values.transcriber.existingSecret }}
         checksum/secret: {{ include (print $.Template.BasePath "/transcriber/xmpp-secret.yaml") . | sha256sum }}
+        {{- end }}
       {{- range $annotation, $value := mergeOverwrite .Values.global.podAnnotations .Values.transcriber.podAnnotations }}
         {{ $annotation }}: {{ $value | quote }}
       {{- end }}
@@ -55,9 +57,9 @@ spec:
           imagePullPolicy: {{ pluck "pullPolicy" .Values.transcriber.image .Values.image | first }}
           envFrom:
           - secretRef:
-              name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-transcriber
+              name: {{ include "jitsi-meet.transcriber.secret" . }}
           - secretRef:
-              name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-jigasi
+              name: {{ include "jitsi-meet.jigasi.secret" . }}
           - configMapRef:
               name: {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-common
           - configMapRef:

--- a/templates/transcriber/xmpp-secret.yaml
+++ b/templates/transcriber/xmpp-secret.yaml
@@ -1,7 +1,8 @@
+{{- if empty .Values.transcriber.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name:  {{ include "call-nested" (list . "prosody" "prosody.fullname") }}-transcriber
+  name: {{ include "jitsi-meet.transcriber.secret" . }}
 type: Opaque
 data:
   {{- if .Values.transcriber.enabled }}
@@ -12,4 +13,4 @@ data:
   JIGASI_XMPP_PASSWORD: {{ default (randAlphaNum 10) .Values.jigasi.xmpp.password | b64enc | quote }}
   {{- end }}
   {{- end }}
-
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -169,6 +169,21 @@ jicofo:
     defaults:
       _jicofo_conf: ""
       _logging_properties: ""
+ 
+  ## Use an existing Kubernetes Secret for Jicofo XMPP credentials.
+  ## When this is set, the chart will NOT create the "<prosody.fullname>-jicofo" Secret.
+  ##
+  ## You must ensure that Prosody references this Secret name in its extraEnvFrom,
+  ## for example in `prosody.extraEnvFrom`:
+  ##
+  ##   - secretRef:
+  ##       name: <your-jicofo-secret-name>
+  ##
+  ## The referenced Secret must contain:
+  ##   - JICOFO_AUTH_USER
+  ##   - JICOFO_AUTH_PASSWORD
+  ##   - JICOFO_COMPONENT_SECRET
+  # existingSecret: ""
 
   xmpp:
     password:
@@ -204,10 +219,24 @@ jvb:
   image:
     repository: jitsi/jvb
 
+  ## Use an existing Kubernetes Secret for JVB XMPP credentials.
+  ## When this is set, the chart will NOT create the "<prosody.fullname>-jvb" Secret.
+  ##
+  ## You must ensure that Prosody references this Secret name in its extraEnvFrom,
+  ## for example in `prosody.extraEnvFrom`:
+  ##
+  ##   - secretRef:
+  ##       name: <your-jvb-secret-name>
+  ##
+  ## The referenced Secret must contain:
+  ##   - JVB_AUTH_USER
+  ##   - JVB_AUTH_PASSWORD
+  # existingSecret: ""
+
   xmpp:
     user: jvb
     password:
-
+ 
   ## Set public IP addresses to be advertised by JVB.
   #  You can specify your nodes' IP addresses,
   #  or IP addresses of proxies/LoadBalancers used for your
@@ -334,6 +363,20 @@ jigasi:
 
   breweryMuc: jigasibrewery
 
+  ## Use an existing Kubernetes Secret for Jigasi XMPP credentials.
+  ## When this is set, the chart will NOT create the "<prosody.fullname>-jigasi" Secret.
+  ##
+  ## You must ensure that Prosody references this Secret name in its extraEnvFrom,
+  ## for example in `prosody.extraEnvFrom`:
+  ##
+  ##   - secretRef:
+  ##       name: <your-jigasi-secret-name>
+  ##
+  ## The referenced Secret must contain:
+  ##   - JIGASI_XMPP_USER
+  ##   - JIGASI_XMPP_PASSWORD
+  # existingSecret: ""
+
   ## Jigasi XMPP user credentials
   xmpp:
     user: jigasi
@@ -379,6 +422,23 @@ transcriber:
     repository: jitsi/jigasi
 
   breweryMuc: jigasibrewery
+
+  ## Use an existing Kubernetes Secret for Transcriber XMPP credentials.
+  ## When this is set, the chart will NOT create the "<prosody.fullname>-transcriber" Secret.
+  ##
+  ## You must ensure that Prosody references this Secret name in its extraEnvFrom,
+  ## for example in `prosody.extraEnvFrom`:
+  ##
+  ##   - secretRef:
+  ##       name: <your-transcriber-secret-name>
+  ##
+  ## The referenced Secret must contain:
+  ##   - JIGASI_TRANSCRIBER_USER
+  ##   - JIGASI_TRANSCRIBER_PASSWORD
+  ## and, when `jigasi.enabled` is false, it must also contain:
+  ##   - JIGASI_XMPP_USER
+  ##   - JIGASI_XMPP_PASSWORD
+  # existingSecret: ""
 
   ## Transcriber XMPP user credentials
   xmpp:
@@ -495,6 +555,22 @@ jibri:
 
   breweryMuc: jibribrewery
   timeout: 90
+
+  ## Use an existing Kubernetes Secret for Jibri XMPP credentials.
+  ## When this is set, the chart will NOT create the "<prosody.fullname>-jibri" Secret.
+  ##
+  ## You must ensure that Prosody references this Secret name in its extraEnvFrom,
+  ## for example in `prosody.extraEnvFrom`:
+  ##
+  ##   - secretRef:
+  ##       name: <your-jibri-secret-name>
+  ##
+  ## The referenced Secret must contain:
+  ##   - JIBRI_XMPP_USER
+  ##   - JIBRI_XMPP_PASSWORD
+  ##   - JIBRI_RECORDER_USER
+  ##   - JIBRI_RECORDER_PASSWORD
+  # existingSecret: ""
 
   ## jibri XMPP user credentials:
   xmpp:


### PR DESCRIPTION
In the production environment, we cannot allow uncontrolled service restarts. Due to the way the Helm chart is structured, every time we render the chart a new set of secrets is generated, which changes the checksum and forces the pods to restart. This behavior causes issues and configuration drift when combined with GitOps tools such as ArgoCD.

This merge request introduces support for using external secrets, for example managed by Sealed Secrets, allowing controlled secret rotation without exposing sensitive values in plain text.