### PR TITLE
Add hostAliases/extraEnvFrom, fix coturn secret, support extraContainers

### DIFF
--- a/templates/coturn/secret.yaml
+++ b/templates/coturn/secret.yaml
@@ -1,4 +1,7 @@
-{{- if not .Values.coturn.staticAuth.existingSecretName }}
+{{- if and
+  .Values.coturn.enabled
+  (not .Values.coturn.staticAuth.existingSecretName)
+}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/templates/jibri/deployment.yaml
+++ b/templates/jibri/deployment.yaml
@@ -40,6 +40,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.jibri.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "jitsi-meet.serviceAccountName" . }}
       volumes:
         - name: config

--- a/templates/jigasi/deployment.yaml
+++ b/templates/jigasi/deployment.yaml
@@ -35,6 +35,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.jigasi.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "jitsi-meet.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.jigasi.podSecurityContext | nindent 8 }}
@@ -67,6 +71,9 @@ spec:
             {{-   range .Values.global.releaseSecretsOverride.extraEnvFrom }}
             - {{    tpl (toYaml . ) $ | indent 14 | trim }}
             {{-   end }}
+            {{- end }}
+            {{- range .Values.jigasi.extraEnvFrom }}
+            - {{  tpl (toYaml . ) $ | indent 14 | trim }}
             {{- end }}
           {{- with .Values.jigasi.livenessProbe }}
           livenessProbe:

--- a/templates/prosody/statefulset.yaml
+++ b/templates/prosody/statefulset.yaml
@@ -26,10 +26,13 @@ spec:
         checksum/secret: {{ include (print $.Template.BasePath "/prosody/secret.yaml") . | sha256sum | quote }}
         checksum/secret-jicofo: {{ include (print $.Template.BasePath "/jicofo/secret.yaml") . | sha256sum | quote }}
         checksum/secret-jvb: {{ include (print $.Template.BasePath "/jvb/secret.yaml") . | sha256sum | quote }}
-        {{- if .Values.coturn.enabled }}
+        {{- if and 
+            .Values.coturn.enabled
+            (not .Values.coturn.staticAuth.existingSecretName)
+        }}
         checksum/secret-coturn: {{ include (print $.Template.BasePath "/coturn/secret.yaml") . | sha256sum | quote }}
         {{- else }}
-        checksum/secret-coturn: {{ printf "disabled" | sha256sum | quote }}
+        checksum/secret-coturn: {{ printf "disabled-or-existing" | sha256sum | quote }}
         {{- end }}
         {{- if and
             .Values.jibri.enabled
@@ -63,6 +66,10 @@ spec:
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.prosody.hostAliases }}
+      hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "jitsi-meet.serviceAccountName" . }}
@@ -118,26 +125,17 @@ spec:
             - configMapRef:
                 name: {{ include "jitsi-meet.prosody.fullname" . }}-coturn
             {{- end }}
-            {{- if and
-                .Values.jibri.enabled
-                (not .Values.jibri.xmpp.existingSecretName)
-            }}
+            {{- if .Values.jibri.enabled }}
             - secretRef:
                 name: {{ include "jitsi-meet.jibri.xmppSecretName" . }}
             - secretRef:
                 name: {{ include "jitsi-meet.jibri.recorderSecretName" . }}
             {{- end }}
-            {{- if and
-                .Values.jigasi.enabled
-                (not .Values.jigasi.xmpp.existingSecretName)
-            }}
+            {{- if .Values.jigasi.enabled }}
             - secretRef:
                 name: {{ include "jitsi-meet.jigasi.secretName" . }}
             {{- end }}
-            {{- if and
-                .Values.transcriber.enabled
-                (not .Values.transcriber.xmpp.existingSecretName)
-            }}
+            {{- if .Values.transcriber.enabled }}
             - secretRef:
                 name: {{ include "jitsi-meet.transcriber.secretName" . }}
             {{- end }}
@@ -149,6 +147,9 @@ spec:
             {{-   range .Values.global.releaseSecretsOverride.extraEnvFrom }}
             - {{    tpl (toYaml . ) $ | indent 14 | trim }}
             {{-   end }}
+            {{- end }}
+            {{- range .Values.prosody.extraEnvFrom }}
+            - {{  tpl (toYaml . ) $ | indent 14 | trim }}
             {{- end }}
           env:
             {{- range .Values.prosody.extraSecrets }}

--- a/templates/transcriber/deployment.yaml
+++ b/templates/transcriber/deployment.yaml
@@ -36,6 +36,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.transcriber.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "jitsi-meet.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.transcriber.podSecurityContext | nindent 8 }}
@@ -78,6 +82,9 @@ spec:
             {{-   range .Values.global.releaseSecretsOverride.extraEnvFrom }}
             - {{    tpl (toYaml .) $ | indent 14 | trim }}
             {{-   end }}
+            {{- end }}
+            {{- range .Values.transcriber.extraEnvFrom }}
+            - {{  tpl (toYaml . ) $ | indent 14 | trim }}
             {{- end }}
           {{- with .Values.transcriber.livenessProbe }}
           livenessProbe:

--- a/templates/web/deployment.yaml
+++ b/templates/web/deployment.yaml
@@ -30,6 +30,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.web.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "jitsi-meet.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.web.podSecurityContext | nindent 8 }}
@@ -161,7 +165,9 @@ spec:
             {{- with .Values.web.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-
+        {{- with .Values.web.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.web.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/values.yaml
+++ b/values.yaml
@@ -143,6 +143,21 @@ web:
   # Use this option if you want to override the nameserver IP.
   #resolverIP: 10.43.0.10
 
+  extraContainers: []
+  #  - name: jitsi-keycloak-adapter
+  #    image: ghcr.io/nordeck/jitsi-keycloak-adapter-v2
+  #    imagePullPolicy: IfNotPresent
+  #    ports:
+  #      - name: http
+  #        containerPort: 9000
+  #    resources:
+  #      requests:
+  #        cpu: 50m
+  #        memory: 64Mi
+  #      limits:
+  #        cpu: 200m
+  #        memory: 256Mi
+
   livenessProbe:
     httpGet:
       path: /
@@ -154,6 +169,7 @@ web:
 
   affinity: {}
   annotations: {}
+  hostAliases: []
   extraEnvs: {}
   nodeSelector: {}
   resources: {}
@@ -351,6 +367,12 @@ prosody:
   #        name: "my-application-secrets"
   #        key: "JITSI_JWT_SECRET"
 
+  extraEnvFrom: []
+  #  - secretRef:
+  #      name: "my-application-secrets"
+  #  - configMapRef:
+  #      name: "my-application-configmap"
+
   metrics:
     enabled: false
     allowed_cidr: "0.0.0.0/0" # change to cluster pod ip cidr
@@ -367,6 +389,7 @@ prosody:
 
   affinity: {}
   annotations: {}
+  hostAliases: []
   extraEnvs: {}
   nodeSelector: {}
   resources: {}
@@ -601,8 +624,15 @@ jigasi:
         - name: Accept
           value: application/json
 
+  extraEnvFrom: []
+  #  - secretRef:
+  #      name: "my-application-secrets"
+  #  - configMapRef:
+  #      name: "my-application-configmap"
+
   affinity: {}
   annotations: {}
+  hostAliases: []
   extraEnvs: {}
   nodeSelector: {}
   resources: {}
@@ -657,6 +687,12 @@ transcriber:
         - name: Accept
           value: application/json
 
+  extraEnvFrom: []
+  #  - secretRef:
+  #      name: "my-application-secrets"
+  #  - configMapRef:
+  #      name: "my-application-configmap"
+
   persistence:
     enabled: false
     #storageClass: ""
@@ -669,6 +705,7 @@ transcriber:
 
   affinity: {}
   annotations: {}
+  hostAliases: []
   extraEnvs: {}
   nodeSelector: {}
   resources: {}
@@ -810,6 +847,7 @@ jibri:
 
   affinity: {}
   annotations: {}
+  hostAliases: []
   extraEnvs: {}
   extraSecrets: []
   extraSecretsFrom: []


### PR DESCRIPTION
This PR extends chart flexibility by allowing hostAliases and extraEnvFrom across Prosody/Jigasi/Transcriber (and hostAliases for Web/Jibri as well), reuses existing secrets for Jigasi/Jibri/Transcriber in Prosody, fixes Coturn secret creation, and adds extraContainers support for the Web deployment.