### PR TITLE
Fix #203 : Specifying jibri.custom.contInit throws "myjitsi-jitsi-meet-jibri-continits" not found error

### DIFF
--- a/templates/jibri/deployment.yaml
+++ b/templates/jibri/deployment.yaml
@@ -51,7 +51,7 @@ spec:
         - name: custom-continits
           configMap:
             defaultMode: 493
-            name: {{ include "jitsi-meet.jibri.fullname" . }}-continits
+            name: {{ include "jitsi-meet.jibri.fullname" . }}-continit
         - name: custom-defaults
           configMap:
             name: {{ include "jitsi-meet.jibri.fullname" . }}-defaults


### PR DESCRIPTION
When you specify jibri.custom.contInit, it throws error during pod startup as attached.
<img width="1380" height="284" alt="image" src="https://github.com/user-attachments/assets/dd143479-0f2d-4ba5-be70-8266e0a313c1" />

Turns out there is a typo in the deployment.yaml and I have now fixed it.
