### PR TITLE
feat(coturn): add resources for metrics and enable prometheus in coturn

### DIFF
--- a/templates/coturn/configmap-config.yaml
+++ b/templates/coturn/configmap-config.yaml
@@ -53,4 +53,7 @@ data:
     allowed-peer-ip={{ . }}
     {{-   end }}
     {{- end }}
+    {{- if .Values.coturn.metrics.enabled }}
+    prometheus
+    {{- end }}
 {{- end }}

--- a/templates/coturn/deployment.yaml
+++ b/templates/coturn/deployment.yaml
@@ -147,6 +147,11 @@ spec:
               protocol: TCP
               containerPort: {{ .Values.coturn.service.ports.turns }}
             {{- end }}
+            {{- if .Values.coturn.metrics.enabled }}
+            - name: tcp-metrics
+              protocol: TCP
+              containerPort: 9641
+            {{- end }}
           {{- with .Values.coturn.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/templates/coturn/service-metrics.yaml
+++ b/templates/coturn/service-metrics.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.coturn.enabled .Values.coturn.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "jitsi-meet.coturn.fullname" . }}-metrics
+  labels:
+    {{- include "jitsi-meet.coturn.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9641
+      protocol: TCP
+      name: tcp-metrics
+  selector:
+    {{- include "jitsi-meet.coturn.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/templates/coturn/servicemonitor-metrics.yaml
+++ b/templates/coturn/servicemonitor-metrics.yaml
@@ -1,0 +1,33 @@
+{{- if and
+       .Values.coturn.enabled
+       .Values.coturn.metrics.enabled
+       .Values.coturn.metrics.serviceMonitor.enabled
+}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "jitsi-meet.coturn.fullname" . }}
+  labels:
+    {{- include "jitsi-meet.coturn.labels" . | nindent 4 }}
+    {{- with .Values.coturn.metrics.serviceMonitor.selector }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  endpoints:
+    - port: tcp-metrics
+      path: /metrics
+
+      {{- with .Values.coturn.metrics.serviceMonitor.honorLabels }}
+      honorLabels: {{ . }}
+      {{- end }}
+
+      {{- with .Values.coturn.metrics.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+  selector:
+    matchLabels:
+      {{- include "jitsi-meet.coturn.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -327,6 +327,16 @@ coturn:
     tcpSocket:
       port: 3478
 
+  # native coturn prometheus metrics (port 9641)
+  metrics:
+    enabled: false
+    serviceMonitor:
+      enabled: true
+      selector:
+        release: prometheus-operator
+      interval: 10s
+      # honorLabels: false
+
   affinity: {}
   annotations: {}
   extraEnvs: {}


### PR DESCRIPTION
This closes #216. Generally minor changes - prometheus is already available in coTURN, just has to be enabled. 