### PR TITLE
Add extra volumes and volume mounts for Jicofo

### DIFF
--- a/templates/jicofo/deployment.yaml
+++ b/templates/jicofo/deployment.yaml
@@ -44,6 +44,9 @@ spec:
         - name: custom-defaults
           configMap:
             name: {{ include "jitsi-meet.jicofo.fullname" . }}-defaults
+        {{- with .Values.jicofo.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.jicofo.image.repository }}:{{ .Values.jicofo.image.tag | default .Chart.AppVersion }}"
@@ -94,6 +97,9 @@ spec:
             - name: custom-defaults
               mountPath: /defaults/logging.properties
               subPath: logging.properties
+            {{- end }}
+            {{- with .Values.jicofo.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
 
         {{- if .Values.jicofo.metrics.enabled }}


### PR DESCRIPTION
Hi,

I am trying right now to use this helm chart with the hardened jitsi images. For allowing them to run with readOnlyRootFilesystem, additional volumeMounts are needed and could be configured with this options.

Docs:
Support hardened-images of jitsi (jicofo), which need /run and /tmp as writable volume (https://github.com/jitsi-contrib/hardened-images/blob/main/docker-compose.yml#L358-L360)