### PR TITLE
Added image override capability for busybox

### DIFF
--- a/docs/samples/values-hardened.yaml
+++ b/docs/samples/values-hardened.yaml
@@ -323,6 +323,7 @@ jigasi:
         runAsUser: 1000
         seccompProfile:
           type: RuntimeDefault
+      image: busybox:1.36
 
 transcriber:
   image:
@@ -376,6 +377,7 @@ transcriber:
         runAsUser: 1000
         seccompProfile:
           type: RuntimeDefault
+      image: busybox:1.36
 
 excalidraw:
   enabled: true

--- a/templates/coturn/deployment.yaml
+++ b/templates/coturn/deployment.yaml
@@ -86,7 +86,7 @@ spec:
               readOnly: true
         {{- end }}
         - name: init-coturn
-          image: busybox:1.36
+          image: {{ .Values.coturn.initContainers.busybox.image | default "busybox:1.36" }}
           command:
             - sh
             - -c

--- a/templates/jigasi/deployment.yaml
+++ b/templates/jigasi/deployment.yaml
@@ -51,7 +51,7 @@ spec:
       {{- end }}
       initContainers:
         - name: init-prosody
-          image: busybox:1.36
+          image: {{ .Values.jigasi.initContainers.busybox.image | default "busybox:1.36" }}
           securityContext:
             {{- toYaml .Values.jigasi.initContainers.busybox.securityContext | nindent 12  }}
           command:

--- a/templates/transcriber/deployment.yaml
+++ b/templates/transcriber/deployment.yaml
@@ -59,7 +59,7 @@ spec:
         {{- end }}
       initContainers:
         - name: init-prosody
-          image: busybox:1.36
+          image: {{ .Values.transcriber.initContainers.busybox.image | default "busybox:1.36" }}
           securityContext:
             {{- toYaml .Values.transcriber.initContainers.busybox.securityContext | nindent 12  }}
           command:

--- a/values.yaml
+++ b/values.yaml
@@ -812,6 +812,7 @@ jigasi:
   initContainers:
     busybox:
       securityContext: { }
+      image: busybox:1.36
 
   affinity: {}
   annotations: {}
@@ -890,6 +891,7 @@ transcriber:
   initContainers:
     busybox:
       securityContext: {}
+      image: busybox:1.36
 
   affinity: {}
   annotations: {}


### PR DESCRIPTION
The other images allow for the ability to override, for example if you're in a locked down environment and using your own registry. 

This allows busybox to have the same functionality.