### PR TITLE
feat: add OCI chart publishing

### DIFF
--- a/.github/workflows/publish-oci-chart.yml
+++ b/.github/workflows/publish-oci-chart.yml
@@ -1,0 +1,28 @@
+name: Publish OCI chart
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Package, push, and sign
+        run: |
+          set -euo pipefail
+          helm package . -d dist/
+          chart="$(ls dist/*.tgz)"
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u "${{ github.actor }}" --password-stdin
+          helm push "$chart" oci://ghcr.io/jitsi-contrib 2>&1 | tee push.log
+          digest="$(awk '/[Dd]igest:/ {print $2}' push.log)"
+          cosign sign --yes "ghcr.io/jitsi-contrib/jitsi-meet@${digest}"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,22 @@ helm repo add jitsi https://jitsi-contrib.github.io/jitsi-helm/
 helm install myjitsi jitsi/jitsi-meet --set publicURL=https://meet.mydomain.com
 ```
 
+Alternatively, install directly from the OCI registry (GitHub Container
+Registry):
+
+```bash
+helm install myjitsi oci://ghcr.io/jitsi-contrib/jitsi-meet --set publicURL=https://meet.mydomain.com
+```
+
+OCI releases are signed with [cosign](https://github.com/sigstore/cosign)
+(keyless). To verify a release before installing:
+
+```bash
+cosign verify ghcr.io/jitsi-contrib/jitsi-meet:<version> \
+  --certificate-identity-regexp '^https://github.com/jitsi-contrib/jitsi-helm/' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
 ## Exposing your Jitsi Meet installation
 
 To be able to do video conferencing with other people, the JVB component should
@@ -241,14 +257,14 @@ transcriber:
 
 The Transcriber streams the meeting audio to a speech-to-text backend, and that
 backend is pluggable. This chart has first-class support for
-[Skynet](https://github.com/jitsi/skynet), Jitsi's own Whisper backend, which
-it can deploy for you (Option 1) or wire to an existing instance (Option 2). You
+[Skynet](https://github.com/jitsi/skynet), Jitsi's own Whisper backend, which it
+can deploy for you (Option 1) or wire to an existing instance (Option 2). You
 can also point the Transcriber at any other Jigasi-supported backend yourself
 (Option 3). **Skynet is not required.**
 
-> **Note:** when this chart deploys Skynet it enables only the `streaming_whisper`
-> module, which does not require Redis. Skynet's summaries/assistant modules are
-> out of scope for this chart.
+> **Note:** when this chart deploys Skynet it enables only the
+> `streaming_whisper` module, which does not require Redis. Skynet's
+> summaries/assistant modules are out of scope for this chart.
 
 ### Option 1: Bundled Skynet (deployed by this chart)
 

--- a/docs/manuals/releasing.md
+++ b/docs/manuals/releasing.md
@@ -37,5 +37,10 @@ Overall, the release process looks like this:
   git push
   ```
 - Create a release on GitHub. This step will also create a tag for the release.
+  Publishing the release triggers the `publish-oci-chart` workflow, which
+  packages the chart, pushes it to `oci://ghcr.io/jitsi-contrib/jitsi-meet`, and
+  signs it with cosign (keyless). No manual step is needed for this. The
+  workflow pins its actions to commit SHAs; bump those SHAs by hand when you
+  want to update them (see the version comments in the workflow file).
 - Release the new version of
   [jitsi-scaler](https://github.com/jitsi-contrib/jitsi-scaler)


### PR DESCRIPTION
Closes #249

Publishes the chart as a signed OCI artifact to GHCR, in addition to the existing gh-pages Helm repo.