### PR TITLE
fix(jvb): use root context for extra-files configmap name

### DIFF
--- a/templates/jvb/deployment.yaml
+++ b/templates/jvb/deployment.yaml
@@ -69,7 +69,7 @@ spec:
         {{- if $.Values.jvb.extraFiles }}
         - name: extra-files
           configMap:
-            name: {{ include "jitsi-meet.jvb.fullname" . }}-extrafiles
+            name: {{ include "jitsi-meet.jvb.fullname" $ }}-extrafiles
             items:
               {{- range $i, $f := $.Values.jvb.extraFiles }}
               - key: extrafile-{{ $i }}


### PR DESCRIPTION
Use root context for extra-files configmap name in JVB deployment