### PR TITLE
fix(coturn): place reloader annotation on Deployment metadata

### DIFF
--- a/templates/coturn/deployment.yaml
+++ b/templates/coturn/deployment.yaml
@@ -8,9 +8,21 @@ metadata:
     {{- with .Values.coturn.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.coturn.annotations }}
+  {{- if or
+         .Values.coturn.turns.enabled
+         .Values.coturn.annotations
+  }}
   annotations:
+    {{- if .Values.coturn.turns.enabled }}
+    {{-   $tlsSecret := .Values.coturn.turns.certificate.existingSecretName }}
+    {{-   if .Values.coturn.turns.certificate.create }}
+    {{-     $tlsSecret = printf "%s-tls" (include "jitsi-meet.coturn.fullname" .) }}
+    {{-   end }}
+    secret.reloader.stakater.com/reload: {{ $tlsSecret }}
+    {{- end }}
+    {{- with .Values.coturn.annotations }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   replicas: {{ .Values.coturn.replicaCount }}
@@ -27,9 +39,6 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/coturn/configmap.yaml") . | sha256sum | quote }}
         checksum/secret: {{ include (print $.Template.BasePath "/coturn/secret.yaml") . | sha256sum | quote }}
-        {{- if .Values.coturn.turns.enabled }}
-        secret.reloader.stakater.com/reload: {{ if .Values.coturn.turns.certificate.create }}{{ include "jitsi-meet.coturn.fullname" . }}-tls{{ else }}{{ .Values.coturn.turns.certificate.existingSecretName }}{{ end }}
-        {{- end }}
         {{- with (mergeOverwrite (dict) .Values.global.podAnnotations .Values.coturn.podAnnotations) }}
         {{- toYaml . | nindent 8  }}
         {{- end }}


### PR DESCRIPTION
Place reloader annotation on Deployment metadata.
Closes #256 