### PR TITLE
Add possibility to add Jibri initContainer

### DIFF
--- a/templates/jibri/deployment.yaml
+++ b/templates/jibri/deployment.yaml
@@ -98,6 +98,10 @@ spec:
         {{- with .Values.jibri.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+    {{- if .Values.jibri.initContainers }}
+      initContainers:
+        {{- toYaml .Values.jibri.initContainers | nindent 8 }}
+    {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.jibri.image.repository }}:{{ .Values.jibri.image.tag | default .Chart.AppVersion }}"


### PR DESCRIPTION
## Description

Add support for configuring an initContainer in the Jibri deployment.

## Problem

Some finalizer scripts require additional tools (e.g. S3 utilities). Installing and mounting these tools through an initContainer provides a simpler and more flexible way to make them available at runtime.

## Usage example
```
jibri:
  initContainers:
    - name: download-mc
      image: busybox:1.38.0
      command: ["/bin/sh", "-c"]
      args:
        - wget -q -O /mc-bin/mc https://dl.min.io/client/mc/release/linux-amd64/mc && chmod +x /mc-bin/mc
      volumeMounts:
        - name: config
          mountPath: /mc-bin
```