### PR TITLE
feat(jvb): add multi-JVB support via Helm values and sample

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -7,7 +7,7 @@ icon: https://jitsi-contrib.github.io/jitsi-helm/jitsi-meet.png
 # This is the *chart* version.
 # This version number should be incremented each time you make
 # changes to the chart and its templates, including the app version.
-version: 2.22.2
+version: 2.23.0
 
 # This is the *application* version.
 # If tags are not set explicitly in values.yaml then appVersion is used as

--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ cosign verify ghcr.io/jitsi-contrib/jitsi-meet:<version> \
 
 JVB must be reachable by all participants (typically on a public IP), and the
 best approach depends on your cluster. The chart supports several options:
-LoadBalancer, NodePort, hostPort (including auto-detected node IP and port
-ranges), hostNetwork, and ingress TCP/UDP forwarding.
+LoadBalancer (including multiple JVBs sharing a small pool of public IPs via
+per-instance Services), NodePort, hostPort (including auto-detected node IP
+and port ranges), hostNetwork, and ingress TCP/UDP forwarding.
 
 See the [Exposing guide](/docs/guides/exposing.md) for all options and examples.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - [Recording and streaming support](#recording-and-streaming-support)
 - [Transcription support](#transcription-support)
 - [Scaling your installation](#scaling-your-installation)
+- [Sizing: capacity, resources, HA, and quality](/docs/guides/sizing.md)
 - [Adding custom Prosody plugins](#adding-custom-prosody-plugins)
 - [Documentation](#documentation)
 

--- a/docs/guides/exposing.md
+++ b/docs/guides/exposing.md
@@ -33,6 +33,67 @@ In this configuration, `jvb.replicaCount` must remain at 1. Increasing the
 replicas will cause UDP packets to be routed to random JVB instances, breaking
 the video connection.
 
+### Option 1.1: Multiple JVBs sharing public IPs via per-instance LoadBalancer services
+
+If you have far fewer public IPs than JVBs you want to run, you can put
+several JVBs behind the same public IP, each on its own UDP port. Every JVB
+still gets its own single-pod `LoadBalancer` Service; Services that land on
+the same public IP share it via your LoadBalancer implementation's IP-sharing
+annotations.
+
+```yaml
+octo:
+  enabled: true
+
+jvb:
+  replicaCount: 1 # must stay 1: one pod per instance
+
+  publicIPs:
+    - 1.2.3.4
+    - 5.6.7.8
+  portsPerIP: 3 # -> 6 bridges: <ip>:10000, <ip>:10001, <ip>:10002
+  UDPPort: 10000
+  disableStun: true # IPs are explicit; STUN would only report the node's egress IP
+
+  service:
+    enabled: true
+    perInstanceServices: true
+    type: LoadBalancer
+    externalTrafficPolicy: Cluster # required, see below
+```
+
+This creates `len(publicIPs) * portsPerIP` JVB instances (6, in the example
+above): `jvb-0`..`jvb-2` behind `1.2.3.4` on ports `10000`-`10002`, `jvb-3`..
+`jvb-5` behind `5.6.7.8` on the same three ports. See
+[the sample config](/docs/samples/values-shared-ip-matrix.yaml).
+
+Important caveats:
+
+- **This only works with a LoadBalancer implementation that supports sharing
+  one IP across several Services**: MetalLB, Cilium LB-IPAM, kube-vip, loxilb.
+  **Cloud-provider NLBs (AWS, GCP, Azure, DigitalOcean) do not support this**
+  — each `LoadBalancer` Service there gets its own address, which is the
+  opposite of the goal. On such clouds, use Option 3/3.1/3.2 (hostPort) with
+  your own external LB or DNAT in front instead.
+- There is no advertise-*port* override in the Jitsi images: JVB always
+  advertises the port it binds. `Service.port`, the container port and
+  `JVB_PORT` are therefore always equal, and there is no way to remap an
+  external port to a different internal one.
+- Because each Service in a sharing group selects a different pod, MetalLB
+  requires `externalTrafficPolicy: Cluster` for the group (it only allows
+  `Local` when all sharing Services select the *same* pods). This adds a hop
+  and SNATs media to the node IP, which is harmless for JVB, but the node's
+  conntrack tables and any firewall in front must allow the whole
+  `UDPPort..UDPPort+portsPerIP-1` range on **every** advertised IP.
+- Don't set `jvb.service.extraPorts` in this mode: a duplicate port on any
+  Service breaks the whole IP-sharing group. Rely on the pod's
+  `readinessProbe` instead.
+- Treat `jvb.publicIPs` as append-only: reordering it re-maps every instance
+  to a different IP and rewrites every Service, causing a full media outage.
+- Deployments update with `strategy: Recreate`, so upgrading a JVB briefly
+  drops its Service to zero endpoints. Jicofo re-invites affected conferences
+  to another bridge.
+
 ## Option 2: Using a NodePort service (public node IP or external LB)
 
 ```yaml

--- a/docs/guides/scaling.md
+++ b/docs/guides/scaling.md
@@ -77,3 +77,11 @@ multiple browser tabs and check the server count which shows the number of JVBs
 hosting this meeting. It should be greater than 1.
 
 ![OCTO server count](/docs/files/octo-server-count.png)
+
+## How many users, and with what resources?
+
+See the [Sizing guide](/docs/guides/sizing.md) for capacity estimates at
+720p/1080p per JVB resource tier, a decision table mapping target concurrent
+users to concrete `resources`/`extraEnvs` settings, and an honest accounting
+of this chart's HA ceiling (Jicofo and Prosody are single-replica, hardcoded
+in their templates, regardless of values).

--- a/docs/guides/scaling.md
+++ b/docs/guides/scaling.md
@@ -46,6 +46,12 @@ Please note that this chart doesn't allow to scale JVB into multiple
 zones/regions yet: all JVB pods will be part of the single OCTO region named
 `all`.
 
+If instead of node-exposed hostPorts you want JVBs behind `LoadBalancer`
+Services while conserving public IPs, see
+[Option 1.1 in the Exposing guide](/docs/guides/exposing.md#option-11-multiple-jvbs-sharing-public-ips-via-per-instance-loadbalancer-services):
+several JVBs can share one public IP, each on its own UDP port, all still in
+the single `all` OCTO region.
+
 ## Testing OCTO
 
 When OCTO is enabled, the participants of a single meeting are distributed

--- a/docs/guides/sizing.md
+++ b/docs/guides/sizing.md
@@ -1,0 +1,149 @@
+# Sizing: capacity, resources, HA, and quality
+
+This guide answers "for N users, what should I set?" It ties together three
+things that trade off against each other: **quality** (resolution/bitrate),
+**resource cost** (CPU/RAM per pod), and **availability** (how much a single
+failure can take down). There is no single number that answers "how many
+users" independent of the other two -- this doc gives you the model and the
+knobs, plus concrete starting points to load-test from.
+
+## The one fact that determines everything else
+
+**JVB does not transcode.** It receives SRTP, decrypts, and re-encrypts/
+forwards to other participants. It never re-encodes video. That means its
+cost is driven by **bytes and packets moved**, not by resolution rendering --
+and the number of bytes/packets moved is:
+
+```
+cost ≈ participants × (streams each participant receives)
+```
+
+`streams each participant receives` is capped by
+`jicofo.extraEnvs.JICOFO_CONF_MAX_VIDEO_SENDERS` (see
+[the quality guide's env var reference](/docs/guides/exposing.md) and the
+[values-sample.yaml](/values-sample.yaml) / [values-sample-1080p.yaml](/values-sample-1080p.yaml)
+files for where this is set). **Without that cap, cost grows roughly with the
+square of room size** (everyone forwards to everyone), which is why a single
+uncapped 720p meeting can overwhelm a bridge at a headcount far below what
+the same bridge handles fine with the cap in place.
+
+This is also why "how many users can a JVB handle" has no single answer:
+100 users with `MAX_VIDEO_SENDERS=3` (everyone effectively sees a 3-tile
+speaker view) costs a fraction of what 30 users with no cap (everyone sees
+everyone in full gallery view) costs.
+
+## Grounding the numbers
+
+Two real, published data points anchor the estimates below (I looked these up
+rather than guessing):
+
+- Jitsi's own DevOps guide: *"4 or 8 CPU with 8GB RAM seems to be a good
+  [videobridge] configuration."*
+- A widely-cited AWS load test: a `c5.xlarge` (4 vCPU/8GB) videobridge
+  sustained on the order of **1000 forwarded streams at ~550Mbps aggregate**
+  -- but that was spread across many separate, smaller conferences, not one
+  giant room. One room concentrates load on one bridge process at once, so a
+  single-conference ceiling is much lower than that aggregate number.
+- Jicofo's own defaults assume ~80-100 participants in a single conference
+  before it wants to spread the room across bridges via Octo
+  (`max-bridge-participants` default 80, `average-participant-stress`
+  default implies ~100). Those defaults are tuned for a "capable" bridge in
+  the 4-8 vCPU range, not a 2 vCPU one.
+
+Everything below extrapolates from those anchors using the cost model above.
+**Treat every number in this doc as a starting point to load-test from, not a
+guarantee** -- real capacity also depends on your network, whether cameras
+are on, screen-share (an extra high-bitrate stream on top), and codec
+(VP8/VP9/AV1 all cost differently).
+
+## Capacity table: one conference, one JVB, with `MAX_VIDEO_SENDERS` capped
+
+| JVB resources | 720p ceiling (senders capped ~5) | 1080p ceiling (senders capped ~3) |
+|---|---|---|
+| 1 vCPU / 1Gi | ~10-15 | not recommended |
+| 2 vCPU / 2Gi ([values-sample.yaml](/values-sample.yaml)) | ~25-35 | ~10-15 |
+| 4 vCPU / 4Gi ([values-sample-1080p.yaml](/values-sample-1080p.yaml)) | ~60-80 | ~30-40 |
+| 8 vCPU / 8Gi | ~120-150 | ~70-90 |
+
+Without a sender cap (`MAX_VIDEO_SENDERS` unset / very high), cut every
+number above roughly in half to a third -- the O(n²) effect starts to bite
+well before these ceilings.
+
+**Beyond a single conference's ceiling, don't make one JVB pod bigger --
+add more JVB pods and let Octo spread the room across them** (this chart's
+`portsPerIP`/`publicIPs` matrix, `octo.enabled: true`). Octo scales
+near-linearly with pod count for this reason: each additional bridge adds
+its own forwarding capacity, and relay traffic between bridges is
+comparatively cheap.
+
+## Availability ceiling of this chart (read this before promising "high HA")
+
+Horizontally scalable, verified in the templates:
+- **JVB** -- any number of instances via the `publicIPs`/`portsPerIP` matrix
+  (see [exposing.md](/docs/guides/exposing.md)). A pod dying only drops the
+  participants on that one bridge; Octo/Jicofo reassign them.
+- **Jibri** -- `jibri.replicaCount`, N concurrent recording/streaming slots.
+- **Web** -- `web.replicaCount`, stateless nginx, trivially horizontal.
+
+**Not horizontally scalable in this chart -- confirmed in the templates,
+hardcoded regardless of values:**
+- **Jicofo** -- `templates/jicofo/deployment.yaml` hardcodes `replicas: 1`.
+  Jicofo is the conference "focus": it owns bridge selection and
+  session signaling for every active conference. If its pod dies, Kubernetes
+  reschedules it, but **every active conference loses its focus during the
+  restart** -- a real, if brief, full-outage window. There is no
+  `jicofo.replicaCount` in this chart's values.
+- **Prosody** -- `templates/prosody/statefulset.yaml` hardcodes
+  `replicas: 1`. Same story for XMPP signaling/MUC membership.
+
+**Implication:** with this chart, "high HA" tops out at *"a JVB pod failure
+is invisible to everyone except its own participants, who get silently
+reassigned"* -- it does **not** mean "no single point of failure at all."
+Jicofo and Prosody remain SPOFs; a `PodDisruptionBudget` and prompt
+rescheduling reduce *downtime* but don't eliminate the outage window. If you
+need Jicofo/Prosody HA, that requires changes this chart doesn't currently
+make (Jicofo's `jicofo-selector` multi-instance mode, Prosody clustering) --
+out of scope here, flagging it rather than pretending otherwise.
+
+## Decision table: for N concurrent users in one room, what to set
+
+Assumes the shared-IP-matrix LoadBalancer topology from
+[values-sample.yaml](/values-sample.yaml), Octo enabled, `disableStun: true`.
+"JVBs" = pod count; give each its own entry in `publicIPs`/`portsPerIP`.
+
+| N users (1 room) | Quality | JVBs × resources | `MAX_VIDEO_SENDERS` | `MAX_BRIDGE_PARTICIPANTS` | Web/Jibri |
+|---|---|---|---|---|---|
+| ≤ 25 | 720p | 1 × (2 vCPU/2Gi) | 5 | 30 | web ×1 |
+| ≤ 60 | 720p | 1 × (4 vCPU/4Gi) | 5 | 60 | web ×2 |
+| ≤ 150 | 720p | 2-3 × (4 vCPU/4Gi), Octo spreads the room | 5 | 60 (per bridge) | web ×2, `PodDisruptionBudget` on web |
+| ≤ 400 | 720p | 6-8 × (4 vCPU/4Gi) | 4-5 | 50-60 | web ×3+, Jibri sized separately per concurrent recording |
+| ≤ 15 | 1080p | 1 × (2 vCPU/2Gi) | 3 | 15 | web ×1 |
+| ≤ 40 | 1080p | 1 × (4 vCPU/4Gi) | 3 | 40 | web ×2 |
+| ≤ 120 | 1080p | 3-4 × (4 vCPU/4Gi), Octo spreads the room | 3 | 40 (per bridge) | web ×2-3 |
+
+Reading this as "least resource for N users": pick the smallest row that
+covers your target N, then load-test at ~120% of that N before calling it
+production-ready -- the table extrapolates from published anchors, it isn't
+a benchmark of your specific cluster/network.
+
+**Recording (Jibri) is sized independently of room size** -- one Jibri pod
+handles exactly one concurrent recording regardless of whether the room has
+10 or 400 people, because it's rendering the composed meeting view once, not
+per-participant. Size `jibri.replicaCount` to how many *simultaneous*
+recordings/streams you expect, not to N.
+
+## Applying this
+
+1. Start from [values-sample.yaml](/values-sample.yaml) (720p) or
+   [values-sample-1080p.yaml](/values-sample-1080p.yaml) (1080p).
+2. Pick your row from the decision table above; set `jvb.resources`,
+   `jvb.publicIPs`/`portsPerIP` (pod count), and the `jicofo.extraEnvs`
+   trio (`JICOFO_CONF_MAX_VIDEO_SENDERS`, `MAX_BRIDGE_PARTICIPANTS`,
+   `BRIDGE_STRESS_THRESHOLD`) accordingly.
+3. Load-test with multiple browser tabs/`jitsi-meet-torture` at your target
+   N before going live; watch `/colibri/stats` or the Grafana dashboard
+   (`jvb.metrics.grafanaDashboards.enabled`) for CPU and packet-loss signals
+   under load.
+4. If you need Jicofo/Prosody to survive a pod failure without a signaling
+   outage, that's a gap in this chart today -- treat it as a known
+   limitation, not something any values change here can close.

--- a/docs/samples/values-multi-jvb-lb-1080p.yaml
+++ b/docs/samples/values-multi-jvb-lb-1080p.yaml
@@ -1,0 +1,148 @@
+# Same shared-IP-matrix topology as values-sample.yaml, tuned for 1080p
+# instead of 720p.
+#
+#   1.2.3.4:10000  jvb-0        5.6.7.8:10000  jvb-3
+#   1.2.3.4:10001  jvb-1        5.6.7.8:10001  jvb-4
+#   1.2.3.4:10002  jvb-2        5.6.7.8:10002  jvb-5
+#
+# 1080p roughly doubles the pixels of 720p and pushes a noticeably higher top
+# simulcast layer bitrate, which raises JVB's per-forwarded-stream CPU/network
+# cost (JVB doesn't transcode -- it's SRTP-encrypt-and-forward -- so cost
+# scales with bytes/packets moved, not "rendering"). Two changes follow from
+# that vs. the 720p sample:
+#   1. Give each JVB more headroom (4 vCPU/4Gi instead of 2/2) -- this matches
+#      Jitsi's own published videobridge sizing guidance ("4 or 8 CPU with
+#      8GB RAM"), scaled down slightly for memory since a single-region Octo
+#      bridge here isn't juggling as many concurrent conferences as a public
+#      SaaS shard.
+#   2. Cap forwarded video senders LOWER than at 720p (3 instead of 5), since
+#      each one now costs more to forward. See docs/guides/sizing.md for the
+#      capacity numbers this is based on and how to re-derive them for your
+#      own hardware.
+
+publicURL: "https://meet.example.com"
+
+octo:
+  enabled: true
+
+jvb:
+  replicaCount: 1 # must be 1: one pod per instance
+
+  publicIPs:
+    - 1.2.3.4
+    - 5.6.7.8
+  portsPerIP: 2 # -> 6 bridges: <ip>:10000, <ip>:10001, <ip>:10002
+  UDPPort: 10000
+
+  # IPs are explicit; STUN would only report the node's egress IP.
+  disableStun: true
+
+  service:
+    enabled: true
+    perInstanceServices: true
+    type: LoadBalancer
+    externalTrafficPolicy: Cluster # required for MetalLB IP sharing
+    extraPorts: [] # must stay empty: duplicate ports break IP sharing
+
+  resources:
+    requests:
+      cpu: "4"
+      memory: 4Gi
+    limits:
+      cpu: "4"
+      memory: 4Gi
+
+  extraEnvs:
+    # Matches the docker-jitsi-meet image default exactly (-Xmx3072m), made
+    # explicit so it's never silently overridden -- and it leaves 1Gi of
+    # headroom under the 4Gi container limit for off-heap RTP/SRTP buffers,
+    # metaspace and thread stacks. Do NOT raise this past ~3Gi on a 4Gi pod.
+    VIDEOBRIDGE_MAX_MEMORY: "3072m"
+
+  # Spread bridges across nodes so one node failure doesn't take out every
+  # instance behind a public IP.
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: jvb
+
+jicofo:
+
+  extraEnvs:
+    JICOFO_ENABLE_BRIDGE_HEALTH_CHECKS: "true"
+    JICOFO_ENABLE_ICE_FAILURE_DETECTION: "true"
+    JICOFO_ENABLE_LOAD_REDISTRIBUTION: "true"
+    # Pick a number that matches how many people you actually expect in one
+    # room before you want it spread across bridges via Octo. Jitsi's own
+    # default is 80 (tuned for a "4-8 vCPU" bridge at 720p); at 1080p on a
+    # 4 vCPU bridge, keep this well under that -- see sizing.md.
+    MAX_BRIDGE_PARTICIPANTS: "40"
+
+    # Lower than the 720p sample's "5" -- each forwarded 1080p stream costs
+    # more, so fewer of them fit in the same CPU budget. Audio stays cheap.
+    JICOFO_CONF_MAX_VIDEO_SENDERS: "3"
+    JICOFO_CONF_MAX_AUDIO_SENDERS: "20"
+
+    # Slightly higher than the 2 vCPU/720p sample's 0.5, reflecting the extra
+    # headroom from doubling JVB's CPU/memory -- still below Jitsi's 0.8
+    # default so a bridge gets relieved before quality on its existing calls
+    # degrades.
+    BRIDGE_STRESS_THRESHOLD: "0.65"
+
+web:
+
+  extraEnvs:
+    # 1080p instead of the 720p sample's cap.
+    RESOLUTION: "1080"
+    # Simulcast lets JVB forward a lower-res layer to bandwidth-constrained
+    # participants instead of transcoding (which JVB doesn't do) -- keep on,
+    # it's what makes 1080p viable for a mixed-bandwidth call.
+    ENABLE_SIMULCAST: "true"
+    # Auto-adjusts sent quality to actual available bandwidth instead of
+    # forcing a fixed resolution regardless of network conditions.
+    ENABLE_ADAPTIVE_MODE: "true"
+    # 1:1 calls go directly peer-to-peer, bypassing JVB entirely -- best
+    # possible quality/latency for 2-person calls and one less thing your
+    # JVBs need to carry.
+    ENABLE_P2P: "true"
+
+
+# Recording/streaming is NOT currently enabled (no `enabled: true` below) --
+# this block is here so the quality/resource tuning is ready when you turn it
+# on. Jibri runs one headless Chromium + ffmpeg pipeline per pod (one
+# recording per pod, not "N users"); 1080p encoding is noticeably heavier
+# than 720p on CPU, hence the bump to 4 vCPU/4Gi vs. the 720p sample's 2/2.
+jibri:
+
+  resources:
+    requests:
+      cpu: "4"
+      memory: 4Gi
+    limits:
+      cpu: "4"
+      memory: 4Gi
+
+  extraEnvs:
+    # 1080p instead of the 720p sample's 1280x720; drives the virtual
+    # display Jibri renders into as well as the ffmpeg output.
+    JIBRI_RECORDING_RESOLUTION: "1920x1080"
+    # Frames/sec Jibri captures and encodes. 30 is the image default; at
+    # 1080p this is meaningfully more CPU than at 720p -- drop to 20-24
+    # first if you see health-check flakiness or dropped frames, before
+    # lowering resolution.
+    JIBRI_RECORDING_FRAMERATE: "30"
+    # x264 encode preset -- "ultrafast" is already the cheapest-CPU option
+    # and the image default. At 1080p there is even less room than at 720p
+    # to trade this for better compression; do not raise it.
+    JIBRI_RECORDING_VIDEO_ENCODE_PRESET_RECORDING: "ultrafast"
+    # x264 constant rate factor: lower = better quality/bigger files/more
+    # CPU, higher = worse quality/smaller files/less CPU. Raised slightly
+    # from the 720p sample's 25 -> 27, since 1080p+ultrafast is already
+    # CPU-heavy and this is the cheapest knob to shed a bit more before
+    # touching resolution/framerate.
+    JIBRI_RECORDING_CONSTANT_RATE_FACTOR: "27"

--- a/docs/samples/values-multi-jvb-lb-720.yaml
+++ b/docs/samples/values-multi-jvb-lb-720.yaml
@@ -1,0 +1,171 @@
+# Example: 6 JVBs sharing 2 public IPs, 3 UDP ports each, in one Octo cluster.
+#
+#   1.2.3.4:10000  jvb-0        5.6.7.8:10000  jvb-3
+#   1.2.3.4:10001  jvb-1        5.6.7.8:10001  jvb-4
+#   1.2.3.4:10002  jvb-2        5.6.7.8:10002  jvb-5
+#
+# Each JVB gets its own single-pod LoadBalancer Service; Services that land on
+# the same public IP share it via MetalLB's IP-sharing annotations. Requires
+# a MetalLB IPAddressPool containing 1.2.3.4 and 5.6.7.8, and a firewall that
+# opens 10000-10002/udp on BOTH addresses. See docs/guides/exposing.md for the
+# full write-up, including why this is MetalLB/Cilium-LB-IPAM/kube-vip/loxilb
+# only (cloud NLBs cannot share one address across several Services).
+
+publicURL: "https://meet.example.com"
+
+octo:
+  enabled: true
+
+jvb:
+  replicaCount: 1 # must be 1: one pod per instance
+
+  publicIPs:
+    - 1.2.3.4
+    - 5.6.7.8
+  portsPerIP: 2 # -> 6 bridges: <ip>:10000, <ip>:10001, <ip>:10002
+  UDPPort: 10000
+
+
+  # IPs are explicit; STUN would only report the node's egress IP.
+  disableStun: true
+
+  service:
+    enabled: true
+    perInstanceServices: true
+    type: LoadBalancer
+    externalTrafficPolicy: Cluster # required for MetalLB IP sharing
+    extraPorts: [] # must stay empty: duplicate ports break IP sharing
+
+  resources:
+    requests:
+      cpu: "2"
+      memory: 2Gi
+    limits:
+      cpu: "2"
+      memory: 2Gi
+
+  extraEnvs:
+    # JVB's JVM defaults to -Xmx3072m regardless of the container's memory
+    # limit, so it WILL eventually get OOMKilled at a 2Gi limit unless the
+    # heap is capped explicitly. Leave headroom under the 2Gi limit for
+    # off-heap RTP/SRTP packet buffers, metaspace and thread stacks.
+    VIDEOBRIDGE_MAX_MEMORY: "1536m"
+
+  # Spread bridges across nodes so one node failure doesn't take out every
+  # instance behind a public IP.
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: jvb
+
+jicofo:
+
+  extraEnvs:
+    JICOFO_ENABLE_BRIDGE_HEALTH_CHECKS: "true"
+    JICOFO_ENABLE_ICE_FAILURE_DETECTION: "true"
+    JICOFO_ENABLE_LOAD_REDISTRIBUTION: "true"
+    # NOTE: forces Octo redistribution past 2 participants in a room -- looks
+    # like a leftover test value. Jitsi's own default is 80; pick a number
+    # that matches how many people you actually expect in one room before you
+    # want it spread across bridges.
+    # MAX_BRIDGE_PARTICIPANTS: "2"
+
+    # Cap forwarded video/audio streams per conference regardless of room
+    # size -- this is the actual protection for a CPU-capped (2 vCPU) JVB:
+    # without it, JVB cost grows ~O(participants^2) as everyone forwards to
+    # everyone. Tune video count to taste; audio is cheap, so it can stay
+    # higher.
+    JICOFO_CONF_MAX_VIDEO_SENDERS: "5"
+    JICOFO_CONF_MAX_AUDIO_SENDERS: "20"
+
+    # Bridges get marked "stressed" (and jicofo stops assigning new
+    # conferences to them) once reported stress crosses this threshold.
+    # Lower than the 0.8 default so a 2 vCPU bridge gets relieved earlier,
+    # before quality on its existing calls degrades.
+    BRIDGE_STRESS_THRESHOLD: "0.5"
+
+  # extraEnvs:
+  #   MAX_BRIDGE_PARTICIPANTS: "3"
+
+web:
+
+
+  extraEnvs:
+    # Caps the resolution the client requests/sends at 720p (this is already
+    # the image default -- set explicitly so it's not accidentally overridden
+    # elsewhere and to document the intent).
+    RESOLUTION: "720"
+    # Simulcast lets JVB forward a lower-res layer to bandwidth-constrained
+    # participants instead of transcoding (which JVB doesn't do) -- keep on,
+    # it's what makes 720p viable for a mixed-bandwidth call.
+    ENABLE_SIMULCAST: "true"
+    # Auto-adjusts sent quality to actual available bandwidth instead of
+    # forcing a fixed resolution regardless of network conditions.
+    ENABLE_ADAPTIVE_MODE: "true"
+    # 1:1 calls go directly peer-to-peer, bypassing JVB entirely -- best
+    # possible quality/latency for 2-person calls and one less thing your
+    # capped JVBs need to carry.
+    ENABLE_P2P: "true"
+    # Codec preference order for desktop/bridge connections (also used for
+    # desktop P2P calls). This is a *preference* list, not a forced codec --
+    # each participant negotiates down to the highest-ranked entry that both
+    # their own hardware/browser and the bridge (or peer, for P2P) support.
+    # Sets config.videoQuality.codecPreferenceOrder (+ config.p2p.*). This is
+    # the image's own default order, just re-quoted here.
+    CODEC_ORDER_JVB: "[\"VP8\", \"H264\",  \"VP9\",\"AV1\" ]"
+    CODEC_ORDER_P2P: "[\"VP8\", \"H264\",  \"VP9\",\"AV1\" ]"
+    # Same preference-order mechanism, applied only to mobile clients (sets
+    # config.videoQuality.mobileCodecPreferenceOrder + config.p2p.*).
+    # Differs from the image default (VP8, VP9, H264, AV1) in two ways:
+    #  - AV1 dropped entirely: AV1 encode/decode is CPU-heavy and often
+    #    lacks hardware support on phones, so it would either fail to
+    #    negotiate or burn battery/thermal-throttle if it did.
+    #  - H264 ranked above VP9: many phone SoCs have H264 hardware
+    #    encode/decode (cheap on battery, consistent quality), while VP9 is
+    #    usually software-only on mobile (more CPU/battery for often-similar
+    #    quality at typical mobile bitrates).
+    # Net effect: prioritizes battery life and negotiation reliability on
+    # mobile over the marginal quality AV1/VP9 can offer when they do have
+    # hardware support.
+    CODEC_ORDER_JVB_MOBILE: "[\"VP8\", \"H264\",  \"VP9\",\"AV1\" ]"
+    CODEC_ORDER_P2P_MOBILE: "[\"VP8\", \"H264\",  \"VP9\",\"AV1\" ]"
+    
+# Recording/streaming is NOT currently enabled (no `enabled: true` below) --
+# this block is here so the quality/resource tuning is ready when you turn it
+# on. Jibri runs one headless Chromium + ffmpeg pipeline per pod (one
+# recording per pod, not "N users"), so 2 vCPU/2Gi caps its encode quality,
+# not the meeting size.
+jibri:
+  #enabled: true
+  resources:
+    requests:
+      cpu: "2"
+      memory: 2Gi
+    limits:
+      cpu: "2"
+      memory: 2Gi
+
+  extraEnvs:
+    # Matches the web-side RESOLUTION cap above; this is already the image
+    # default, set explicitly to document intent and drive the virtual
+    # display Jibri renders into.
+    JIBRI_RECORDING_RESOLUTION: "1280x720"
+    # Frames/sec Jibri captures and encodes. 30 is the image default; if you
+    # see health-check flakiness or dropped frames under a busy layout at
+    # only 2 vCPU, drop this to 20 before lowering resolution.
+    JIBRI_RECORDING_FRAMERATE: "30"
+    # x264 encode preset -- "ultrafast" is already the cheapest-CPU option
+    # and the image default; do not raise this (e.g. to "fast"/"medium") on a
+    # CPU-capped pod, it trades CPU for compression efficiency and 2 vCPU
+    # doesn't have room to spare.
+    JIBRI_RECORDING_VIDEO_ENCODE_PRESET_RECORDING: "ultrafast"
+    # x264 constant rate factor: lower = better quality/bigger files/more
+    # CPU, higher = worse quality/smaller files/less CPU. 25 is the image
+    # default and a reasonable balance at 2 vCPU; raise toward 28-30 first if
+    # you need to shed CPU, before touching resolution/framerate.
+    JIBRI_RECORDING_CONSTANT_RATE_FACTOR: "25"

--- a/docs/samples/values-shared-ip-matrix.yaml
+++ b/docs/samples/values-shared-ip-matrix.yaml
@@ -1,0 +1,58 @@
+# Example: 6 JVBs sharing 2 public IPs, 3 UDP ports each, in one Octo cluster.
+#
+#   1.2.3.4:10000  jvb-0        5.6.7.8:10000  jvb-3
+#   1.2.3.4:10001  jvb-1        5.6.7.8:10001  jvb-4
+#   1.2.3.4:10002  jvb-2        5.6.7.8:10002  jvb-5
+#
+# Each JVB gets its own single-pod LoadBalancer Service; Services that land on
+# the same public IP share it via MetalLB's IP-sharing annotations. Requires
+# a MetalLB IPAddressPool containing 1.2.3.4 and 5.6.7.8, and a firewall that
+# opens 10000-10002/udp on BOTH addresses. See docs/guides/exposing.md for the
+# full write-up, including why this is MetalLB/Cilium-LB-IPAM/kube-vip/loxilb
+# only (cloud NLBs cannot share one address across several Services).
+
+publicURL: "https://meet.example.com"
+
+octo:
+  enabled: true
+
+jvb:
+  replicaCount: 1 # must be 1: one pod per instance
+
+  publicIPs:
+    - 1.2.3.4
+    - 5.6.7.8
+  portsPerIP: 3 # -> 6 bridges: <ip>:10000, <ip>:10001, <ip>:10002
+  UDPPort: 10000
+
+  # IPs are explicit; STUN would only report the node's egress IP.
+  disableStun: true
+
+  service:
+    enabled: true
+    perInstanceServices: true
+    type: LoadBalancer
+    externalTrafficPolicy: Cluster # required for MetalLB IP sharing
+    extraPorts: [] # must stay empty: duplicate ports break IP sharing
+
+  resources:
+    requests:
+      cpu: "1"
+      memory: 1Gi
+
+  # Spread bridges across nodes so one node failure doesn't take out every
+  # instance behind a public IP.
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: jvb
+
+# For testing bridge spread only -- the default threshold is 80 participants:
+#jicofo:
+#  extraEnvs:
+#    MAX_BRIDGE_PARTICIPANTS: "3"

--- a/templates/jicofo/deployment.yaml
+++ b/templates/jicofo/deployment.yaml
@@ -26,6 +26,13 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/jicofo/configmap.yaml") . | sha256sum | quote }}
         checksum/secret: {{ include (print $.Template.BasePath "/jicofo/secret.yaml") . | sha256sum | quote }}
+        {{- if and
+               .Values.jicofo.metrics.enabled
+               .Values.jicofo.metrics.prometheusAnnotations
+        }}
+        prometheus.io/port: "9996"
+        prometheus.io/scrape: "true"
+        {{- end }}
         {{- with (mergeOverwrite (dict) .Values.global.podAnnotations .Values.jicofo.podAnnotations) }}
         {{- toYaml . | nindent 8  }}
         {{- end }}

--- a/templates/jicofo/podmonitor.yaml
+++ b/templates/jicofo/podmonitor.yaml
@@ -1,4 +1,7 @@
-{{- if .Values.jicofo.metrics.enabled }}
+{{- if and
+       .Values.jicofo.metrics.enabled
+       .Values.jicofo.metrics.podMonitor.enabled
+}}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:

--- a/templates/jvb/_helpers.tpl
+++ b/templates/jvb/_helpers.tpl
@@ -23,3 +23,129 @@ app.kubernetes.io/component: "jvb"
 {{ include "jitsi-meet.selectorLabels" . }}
 app.kubernetes.io/component: "jvb"
 {{- end -}}
+
+{{/*
+Per-instance resource name: <fullname>-jvb-<index>
+Call as: include "jitsi-meet.jvb.instanceFullname" (dict "ctx" $ "index" $i)
+*/}}
+{{- define "jitsi-meet.jvb.instanceFullname" -}}
+{{ printf "%s-%v" (include "jitsi-meet.jvb.fullname" .ctx) .index | trunc 63 | trimSuffix "-" }}
+{{- end -}}
+
+{{/*
+Normalized JVB instance list -- the single source of truth for how many JVB
+instances exist and which public IP / UDP port each one owns.
+
+Consume with:
+  {{- $instances := fromYamlArray (include "jitsi-meet.jvb.instanceList" .) }}
+
+Each element is a dict with keys: index, publicIP, port, nodePort,
+sharingKey, firstOnIP.
+
+When jvb.publicIPs and jvb.portsPerIP are both set, this declares an
+IP x port matrix: len(publicIPs) * portsPerIP instances, indexed so that
+instance i sits on publicIPs[i/portsPerIP] at port UDPPort+(i%portsPerIP).
+
+Otherwise it falls back to the legacy behavior: one instance, or (when
+useHostPort is enabled) portRangeSize instances, none carrying a per-instance
+publicIP -- callers must fall back to the joined jvb.publicIPs list.
+*/}}
+{{- define "jitsi-meet.jvb.instanceList" -}}
+{{- $v := .Values.jvb -}}
+{{- $out := list -}}
+{{- if and $v.publicIPs $v.portsPerIP -}}
+{{-   $per := int $v.portsPerIP -}}
+{{-   range $i := until (int (mul (len $v.publicIPs) $per)) -}}
+{{-     $ip := index $v.publicIPs (div $i $per) -}}
+{{-     $out = append $out (dict
+          "index" $i
+          "publicIP" $ip
+          "port" (add (int $v.UDPPort) (mod $i $per))
+          "nodePort" (ternary $v.nodePort nil (eq $per 1))
+          "sharingKey" $ip
+        ) -}}
+{{-   end -}}
+{{- else -}}
+{{/*  Legacy path: identical instance count and ports as before this change. */}}
+{{-   $count := 1 -}}
+{{-   if $v.useHostPort }}{{ $count = int ($v.portRangeSize | default 1) }}{{ end -}}
+{{-   range $i := until $count -}}
+{{-     $out = append $out (dict
+          "index" $i
+          "publicIP" ""
+          "port" (add (int $v.UDPPort) $i)
+          "nodePort" $v.nodePort
+          "sharingKey" ""
+        ) -}}
+{{-   end -}}
+{{- end -}}
+{{/* mark the first Service on each public IP, for extraPorts placement */}}
+{{- $seen := dict -}}
+{{- $final := list -}}
+{{- range $inst := $out -}}
+{{-   $k := $inst.publicIP | default "_" -}}
+{{-   $_ := set $inst "firstOnIP" (not (hasKey $seen $k)) -}}
+{{-   $_ := set $seen $k true -}}
+{{-   $final = append $final $inst -}}
+{{- end -}}
+{{- toYaml $final -}}
+{{- end -}}
+
+{{/*
+Guard rails for the JVB instance matrix / per-instance Services. Call once
+with `{{- include "jitsi-meet.jvb.validate" . }}` -- it renders nothing on
+success and aborts the whole render via `fail` otherwise.
+*/}}
+{{- define "jitsi-meet.jvb.validate" -}}
+{{- $v := .Values.jvb -}}
+{{- $instances := fromYamlArray (include "jitsi-meet.jvb.instanceList" .) -}}
+
+{{- if and $v.portsPerIP (gt (int ($v.portRangeSize | default 1)) 1) -}}
+{{-   fail "jvb: jvb.portsPerIP replaces jvb.portRangeSize; do not set both" -}}
+{{- end -}}
+{{- if and $v.portsPerIP (not $v.publicIPs) -}}
+{{-   fail "jvb: jvb.portsPerIP requires a non-empty jvb.publicIPs list" -}}
+{{- end -}}
+{{- if and $v.portsPerIP (lt (int $v.portsPerIP) 1) -}}
+{{-   fail "jvb: jvb.portsPerIP must be >= 1" -}}
+{{- end -}}
+
+{{- if and $v.service.enabled $v.service.perInstanceServices -}}
+{{-   if ne (int $v.replicaCount) 1 -}}
+{{-     fail "jvb: jvb.replicaCount must be 1 when jvb.service.perInstanceServices is enabled (each Service targets exactly one pod; more replicas send UDP to a random bridge)" -}}
+{{-   end -}}
+{{-   if $v.useHostNetwork -}}
+{{-     fail "jvb: jvb.service.perInstanceServices is incompatible with jvb.useHostNetwork" -}}
+{{-   end -}}
+{{-   if $v.useHostPort -}}
+{{-     fail "jvb: jvb.service.perInstanceServices is incompatible with jvb.useHostPort" -}}
+{{-   end -}}
+{{-   if and (gt (len $instances) 1) (eq $v.service.type "LoadBalancer") -}}
+{{-     if not $v.service.ipSharing.annotationKey -}}
+{{-       fail "jvb: jvb.service.ipSharing.annotationKey must be set when several LoadBalancer Services share a public IP" -}}
+{{-     end -}}
+{{-     if eq $v.service.externalTrafficPolicy "Local" -}}
+{{-       fail "jvb: shared LoadBalancer IPs require jvb.service.externalTrafficPolicy: Cluster (MetalLB rejects Local when Services select different pods)" -}}
+{{-     end -}}
+{{-   end -}}
+{{-   if and $v.nodePort (gt (len $instances) 1) -}}
+{{-     fail "jvb: jvb.nodePort cannot be shared by multiple per-instance Services; unset it to auto-allocate a nodePort per instance" -}}
+{{-   end -}}
+{{- end -}}
+
+{{- if and $v.service.enabled (not $v.service.perInstanceServices) (gt (len $instances) 1) -}}
+{{-   fail "jvb: more than one JVB instance behind a single shared Service routes UDP to a random bridge; set jvb.service.perInstanceServices=true, or disable jvb.service and use hostPort" -}}
+{{- end -}}
+
+{{- $seenIPPort := dict -}}
+{{- range $inst := $instances -}}
+{{-   $key := printf "%s/%v" ($inst.publicIP | default "_") $inst.port -}}
+{{-   if hasKey $seenIPPort $key -}}
+{{-     fail (printf "jvb: duplicate publicIP/port combination %s (instances %v and %v)" $key (index $seenIPPort $key) $inst.index) -}}
+{{-   end -}}
+{{-   $_ := set $seenIPPort $key $inst.index -}}
+{{-   if or (lt (int $inst.port) 1024) (gt (int $inst.port) 65535) -}}
+{{-     fail (printf "jvb: instance %v port %v out of range 1024-65535" $inst.index $inst.port) -}}
+{{-   end -}}
+{{- end -}}
+{{- end -}}

--- a/templates/jvb/_helpers.tpl
+++ b/templates/jvb/_helpers.tpl
@@ -148,4 +148,73 @@ success and aborts the whole render via `fail` otherwise.
 {{-     fail (printf "jvb: instance %v port %v out of range 1024-65535" $inst.index $inst.port) -}}
 {{-   end -}}
 {{- end -}}
+
+{{- $g := $v.gracefulShutdown -}}
+{{- if and $g.preStop.enabled (not $g.enabled) -}}
+{{-   fail "jvb: jvb.gracefulShutdown.preStop.enabled requires jvb.gracefulShutdown.enabled (the hook needs SHUTDOWN_REST_ENABLED)" -}}
+{{- end -}}
+{{- if and $g.preStop.enabled (ge (int $g.preStop.maxWaitSeconds) (sub (int $g.terminationGracePeriodSeconds) 10)) -}}
+{{-   fail "jvb: jvb.gracefulShutdown.preStop.maxWaitSeconds must be at least 10s below jvb.gracefulShutdown.terminationGracePeriodSeconds, or kubelet SIGKILLs mid-drain" -}}
+{{- end -}}
+{{- if and $g.preStop.enabled (lt (int $g.preStop.pollIntervalSeconds) 1) -}}
+{{-   fail "jvb: jvb.gracefulShutdown.preStop.pollIntervalSeconds must be >= 1" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+preStop drain script for JVB. Call with the ROOT context: $
+  {{- include "jitsi-meet.jvb.preStopScript" $ | nindent 18 }}
+
+POSIX sh, no jq (not guaranteed present in the jitsi/jvb image), tries curl
+then wget. Always exits 0 -- a failed/timed-out hook should only produce log
+noise; kubelet proceeds to SIGTERM either way (see the long comment on
+jvb.gracefulShutdown in values.yaml for why this hook is defence-in-depth
+only, not the primary drain mechanism, in the perInstanceServices topology).
+*/}}
+{{- define "jitsi-meet.jvb.preStopScript" -}}
+{{- $g := .Values.jvb.gracefulShutdown -}}
+{{- $wait := int $g.preStop.maxWaitSeconds -}}
+{{- $poll := int $g.preStop.pollIntervalSeconds -}}
+{{- $min  := int $g.preStop.minParticipants -}}
+- /bin/sh
+- -c
+- |
+  set -u
+  B=http://localhost:8080
+  if command -v curl >/dev/null 2>&1; then
+    GET() { curl -sf -m 5 "$1"; }
+    POST() { curl -sf -m 5 -H 'Content-Type: application/json' \
+      -d '{"graceful-shutdown":"true"}' "$1"; }
+  elif command -v wget >/dev/null 2>&1; then
+    GET() { wget -q -O - -T 5 "$1"; }
+    POST() { wget -q -O - -T 5 --header='Content-Type: application/json' \
+      --post-data='{"graceful-shutdown":"true"}' "$1"; }
+  else
+    echo "prestop: neither curl nor wget in image; skipping drain" >&2
+    exit 0
+  fi
+  num() { printf '%s' "$2" | tr ',{}' '\n\n\n' \
+    | sed -n 's/.*"'"$1"'"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' \
+    | head -1; }
+  POST "$B/colibri/shutdown" >/dev/null 2>&1 \
+    || { echo "prestop: shutdown POST failed (is SHUTDOWN_REST_ENABLED set?)" >&2; exit 0; }
+  e=0
+  while [ "$e" -lt {{ $wait }} ]; do
+    s=$(GET "$B/colibri/stats" 2>/dev/null) || exit 0
+    l=$(num local_endpoints "$s")
+    if [ -z "$l" ]; then
+      p=$(num participants "$s"); o=$(num octo_endpoints "$s")
+      [ -n "$p" ] || p=0
+      [ -n "$o" ] || o=0
+      l=$((p - o))
+    fi
+    if [ "$l" -le {{ $min }} ]; then
+      echo "prestop: drained ($l local participants)" >&2
+      exit 0
+    fi
+    sleep {{ $poll }}
+    e=$((e + {{ $poll }}))
+  done
+  echo "prestop: drain timed out after {{ $wait }}s with $l local participants remaining" >&2
+  exit 0
 {{- end -}}

--- a/templates/jvb/deployment.yaml
+++ b/templates/jvb/deployment.yaml
@@ -56,6 +56,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "jitsi-meet.serviceAccountName" $ }}
+      {{- if $.Values.jvb.gracefulShutdown.enabled }}
+      terminationGracePeriodSeconds: {{ $.Values.jvb.gracefulShutdown.terminationGracePeriodSeconds }}
+      {{- end }}
       securityContext:
         {{- toYaml $.Values.jvb.podSecurityContext | nindent 8 }}
       {{- if $.Values.jvb.useHostNetwork }}
@@ -128,6 +131,10 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
             {{- end }}
+            {{- if $.Values.jvb.gracefulShutdown.enabled }}
+            - name: SHUTDOWN_REST_ENABLED
+              value: "true"
+            {{- end }}
           ports:
             - name: rtp-udp
               containerPort: {{ $udpPort }}
@@ -147,6 +154,13 @@ spec:
           {{- with $.Values.jvb.readinessProbe }}
           readinessProbe:
             {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if and $.Values.jvb.gracefulShutdown.enabled $.Values.jvb.gracefulShutdown.preStop.enabled }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  {{- include "jitsi-meet.jvb.preStopScript" $ | nindent 18 }}
           {{- end }}
           resources:
             {{- toYaml $.Values.jvb.resources | nindent 12 }}
@@ -187,6 +201,10 @@ spec:
 
       {{- with $.Values.jvb.affinity }}
       affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $.Values.jvb.topologySpreadConstraints }}
+      topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with $.Values.jvb.nodeSelector }}

--- a/templates/jvb/deployment.yaml
+++ b/templates/jvb/deployment.yaml
@@ -1,17 +1,14 @@
-{{- $basePort := .Values.jvb.UDPPort }}
+{{- include "jitsi-meet.jvb.validate" . }}
+{{- $instances := fromYamlArray (include "jitsi-meet.jvb.instanceList" .) }}
 
-{{- $rangeSize := 1 }}
-{{- if .Values.jvb.useHostPort }}
-{{-   $rangeSize = .Values.jvb.portRangeSize | default 1 }}
-{{- end }}
-
-{{- range $i := until (int $rangeSize) }}
-{{- $udpPort := add $basePort $i }}
+{{- range $inst := $instances }}
+{{- $i := $inst.index }}
+{{- $udpPort := $inst.port }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "jitsi-meet.jvb.fullname" $ }}-{{ $i }}
+  name: {{ include "jitsi-meet.jvb.instanceFullname" (dict "ctx" $ "index" $i) }}
   labels:
     {{- include "jitsi-meet.jvb.labels" $ | nindent 4 }}
     instance: {{ $i | quote }}
@@ -28,7 +25,7 @@ spec:
     matchLabels:
       {{- include "jitsi-meet.jvb.selectorLabels" $ | nindent 6 }}
       instance: {{ $i | quote }}
-  {{- if $.Values.jvb.useHostPort }}
+  {{- if or $.Values.jvb.useHostPort $.Values.jvb.service.perInstanceServices }}
   strategy:
     type: Recreate
   {{- end }}
@@ -103,7 +100,10 @@ spec:
           env:
             - name: JVB_PORT
               value: {{ $udpPort | quote }}
-            {{- if $.Values.jvb.publicIPs }}
+            {{- if $inst.publicIP }}
+            - name: JVB_ADVERTISE_IPS
+              value: {{ $inst.publicIP | quote }}
+            {{- else if $.Values.jvb.publicIPs }}
             - name: JVB_ADVERTISE_IPS
               value: {{ $.Values.jvb.publicIPs | join "," | quote }}
             {{- else if $.Values.jvb.useNodeIP }}

--- a/templates/jvb/service.yaml
+++ b/templates/jvb/service.yaml
@@ -1,8 +1,79 @@
-{{- if and
-       .Values.jvb.service.enabled
-       (not .Values.jvb.useHostPort)
-       (not .Values.jvb.useHostNetwork)
-}}
+{{- if .Values.jvb.service.enabled }}
+
+{{- if and .Values.jvb.service.perInstanceServices (not .Values.jvb.useHostNetwork) }}
+{{- $instances := fromYamlArray (include "jitsi-meet.jvb.instanceList" .) }}
+{{- $share := .Values.jvb.service.ipSharing | default dict }}
+{{- range $inst := $instances }}
+{{- $i := $inst.index }}
+{{- $ann := deepCopy ($.Values.jvb.service.annotations | default dict) }}
+{{- if and $inst.publicIP (eq $.Values.jvb.service.type "LoadBalancer") }}
+{{-   with $share.annotationKey }}
+{{-     $_ := set $ann . (regexReplaceAll "[^A-Za-z0-9._-]" ($inst.sharingKey | toString) "-") }}
+{{-   end }}
+{{-   with $share.ipAnnotationKey }}
+{{-     $_ := set $ann . $inst.publicIP }}
+{{-   end }}
+{{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "jitsi-meet.jvb.instanceFullname" (dict "ctx" $ "index" $i) }}
+  labels:
+    {{- include "jitsi-meet.jvb.labels" $ | nindent 4 }}
+    instance: {{ $i | quote }}
+  {{- with $ann }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ $.Values.jvb.service.type }}
+  {{- with $.Values.jvb.service.loadBalancerClass }}
+  loadBalancerClass: {{ . }}
+  {{- end }}
+  {{- if and $inst.publicIP (eq $.Values.jvb.service.type "LoadBalancer") (not $share.ipAnnotationKey) }}
+  loadBalancerIP: {{ $inst.publicIP | quote }}
+  {{- else }}
+  {{- with $.Values.jvb.service.loadBalancerIP }}
+  loadBalancerIP: {{ . }}
+  {{- end }}
+  {{- end }}
+  {{- with $.Values.jvb.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ . }}
+  {{- end }}
+  ports:
+    - name: rtp-udp
+      protocol: UDP
+      port: {{ $inst.port }}
+      targetPort: {{ $inst.port }}
+      {{- if and
+             $inst.nodePort
+             (or
+                (eq $.Values.jvb.service.type "NodePort")
+                (eq $.Values.jvb.service.type "LoadBalancer")
+             )
+      }}
+      nodePort: {{ $inst.nodePort }}
+      {{- end }}
+    {{- if and $.Values.jvb.service.extraPorts (or $inst.firstOnIP $.Values.jvb.service.extraPortsOnEveryInstance) }}
+    {{ toYaml $.Values.jvb.service.extraPorts | indent 4 | trim }}
+    {{- end }}
+  {{- with $.Values.jvb.service.externalIPs }}
+  externalIPs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if or
+         (eq $.Values.jvb.service.type "NodePort")
+         (eq $.Values.jvb.service.type "LoadBalancer")
+  }}
+  externalTrafficPolicy: {{ $.Values.jvb.service.externalTrafficPolicy }}
+  {{- end }}
+  selector:
+    {{- include "jitsi-meet.jvb.selectorLabels" $ | nindent 4 }}
+    instance: {{ $i | quote }}
+{{- end }}
+
+{{- else if and (not .Values.jvb.useHostPort) (not .Values.jvb.useHostNetwork) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -52,4 +123,6 @@ spec:
   {{- end }}
   selector:
     {{- include "jitsi-meet.jvb.selectorLabels" . | nindent 4 }}
+{{- end }}
+
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -857,7 +857,13 @@ jvb:
   extraVolumeMounts: []
   labels: {}
   nodeSelector: {}
-  resources: {}
+  resources:
+    requests:
+      cpu: "2"
+      memory: 2Gi
+    limits:
+      cpu: "2"
+      memory: 2Gi
   podAnnotations: {}
   podLabels: {}
   podSecurityContext: {}
@@ -1240,7 +1246,13 @@ jibri:
   hostAliases: []
   labels: {}
   nodeSelector: {}
-  resources: {}
+  resources:
+    requests:
+      cpu: "2"
+      memory: 2Gi
+    limits:
+      cpu: "2"
+      memory: 2Gi
   podAnnotations: {}
   podLabels: {}
   podSecurityContext: {}

--- a/values.yaml
+++ b/values.yaml
@@ -825,6 +825,38 @@ jvb:
       path: /about/health
       port: 8080
 
+  # Graceful drain. Enables JVB's REST shutdown endpoint and, optionally, a
+  # preStop hook that asks the bridge to drain before SIGTERM.
+  #
+  # READ THIS FIRST if you use jvb.service.perInstanceServices: in that
+  # topology each Service has exactly ONE backing pod. The moment the pod
+  # goes Terminating its EndpointSlice entry flips ready:false, kube-proxy
+  # drops it from the (now empty) Service and FLUSHES the UDP conntrack
+  # entries for it, so media for already-connected participants stops
+  # immediately -- the draining bridge is alive but unreachable through its
+  # LoadBalancer IP. perInstanceServices also forces strategy: Recreate, so
+  # every second the hook waits is a second of downtime for that instance,
+  # not a second of protected calls. Keep preStop.maxWaitSeconds SMALL and
+  # drain out-of-band for real maintenance: POST a drain to the pod while it
+  # is still Ready (existing calls finish untouched, Jicofo stops assigning
+  # new ones to it), poll /colibri/stats until local participants hit 0,
+  # *then* delete/upgrade the pod.
+  gracefulShutdown:
+    # Sets SHUTDOWN_REST_ENABLED=true -> videobridge.rest.shutdown.enabled.
+    # Needed for BOTH the preStop hook and out-of-band drains. Requires the
+    # private COLIBRI REST API, which this chart already enables.
+    enabled: false
+    # Time kubelet gives the pod between SIGTERM and SIGKILL. Must exceed
+    # preStop.maxWaitSeconds; the hook runs INSIDE this budget.
+    terminationGracePeriodSeconds: 60
+    preStop:
+      enabled: false
+      # Hard ceiling on the drain wait. 30-60s, not minutes: see above.
+      maxWaitSeconds: 30
+      pollIntervalSeconds: 5
+      # Exit the hook once local (non-relay) participants drop to this.
+      minParticipants: 0
+
   metrics:
     enabled: false
     image:
@@ -857,6 +889,19 @@ jvb:
       annotations: {}
 
   affinity: {}
+  # Spread JVB pods evenly across nodes (in addition to/instead of affinity's
+  # preferred anti-affinity). Use whenUnsatisfiable: ScheduleAnyway, not
+  # DoNotSchedule -- with strategy: Recreate (useHostPort or
+  # perInstanceServices), an unsatisfiable hard constraint leaves the old
+  # pod already deleted and the new one stuck Pending: unbounded outage for
+  # that instance.
+  topologySpreadConstraints: []
+  #  - maxSkew: 1
+  #    topologyKey: kubernetes.io/hostname
+  #    whenUnsatisfiable: ScheduleAnyway
+  #    labelSelector:
+  #      matchLabels:
+  #        app.kubernetes.io/component: jvb
   annotations: {}
   extraEnvs: {}
   extraFiles: []

--- a/values.yaml
+++ b/values.yaml
@@ -627,6 +627,13 @@ jicofo:
       tag: "1.3.2"
     resources: {}
     securityContext: {}
+    # Add prometheus.io/scrape + prometheus.io/port pod annotations so a
+    # plain annotation-based Prometheus scrape config picks this pod up
+    # directly, without needing the Prometheus Operator's PodMonitor CRD
+    # (jicofo/podmonitor.yaml, rendered separately whenever metrics.enabled).
+    # If the exporter doesn't serve on the default /metrics path, add
+    # prometheus.io/path via jicofo.podAnnotations.
+    prometheusAnnotations: false
 
   affinity: {}
   annotations: {}

--- a/values.yaml
+++ b/values.yaml
@@ -646,6 +646,7 @@ jicofo:
 ## #############################################################################
 ## JVB configuration
 ## #############################################################################
+
 jvb:
   replicaCount: 1
 
@@ -713,14 +714,36 @@ jvb:
   # If > 1, UDPPort acts as the base for the port range.
   # This range logic is only valid if useHostPort is enabled.
   portRangeSize: 1
+  # Number of consecutive UDP ports to use PER public IP. Together with
+  # publicIPs this declares an IP x port matrix and creates
+  # len(publicIPs) * portsPerIP JVB instances, each with its own Deployment
+  # and (when service.perInstanceServices is enabled) its own LoadBalancer
+  # Service. This is the Service-based counterpart to portRangeSize/hostPort
+  # and lets several JVBs share a small pool of public IPs, one UDP port each.
+  #
+  #   publicIPs: [1.2.3.4, 5.6.7.8]
+  #   portsPerIP: 3
+  #   UDPPort: 10000
+  # =>  jvb-0 1.2.3.4:10000   jvb-3 5.6.7.8:10000
+  #     jvb-1 1.2.3.4:10001   jvb-4 5.6.7.8:10001
+  #     jvb-2 1.2.3.4:10002   jvb-5 5.6.7.8:10002
+  #
+  # Unset preserves the legacy behavior, where every pod advertises the whole
+  # publicIPs list. Mutually exclusive with portRangeSize. Treat publicIPs as
+  # append-only in practice: reordering it re-maps every instance to a
+  # different IP and rewrites every Service, causing a full media outage.
+  #portsPerIP: 3
   # Use a pre-defined external port for NodePort or LoadBalancer service,
   # if needed. Will allocate a random port from allowed range if unset.
   # (Default NodePort range for K8s is 30000-32767)
+  # Cannot be set together with portsPerIP when it produces more than one
+  # instance per IP -- unset it to auto-allocate a nodePort per instance.
   #nodePort: 10000
 
   service:
     # When the service is enabled, JVB's replicaCount and portRangeSize must be
-    # 1. This means that there can only be one JVB in this case.
+    # 1, unless perInstanceServices is enabled (see below). This means that
+    # there can only be one JVB in this case.
     enabled: true
     type: ClusterIP
     externalTrafficPolicy: Cluster
@@ -741,10 +764,49 @@ jvb:
     #  service.beta.kubernetes.io/do-loadbalancer-healthcheck-protocol: "tcp"
     # Add extra ports to the service.
     # An example below is needed for DigitalOcean managed k8s setups.
+    # When perInstanceServices shares one public IP across several Services,
+    # duplicate ports break the IP-sharing group, so extraPorts is only
+    # attached to the first Service on each public IP (see
+    # extraPortsOnEveryInstance below).
     extraPorts: []
     #  - name: http-healthcheck
     #    port: 8080
     #    protocol: TCP
+
+    # Emit ONE Service per JVB instance (see publicIPs/portsPerIP above)
+    # instead of a single Service shared by all JVB pods. Each Service's
+    # selector is pinned to that instance's `instance` label, so it routes
+    # UDP to exactly one pod on exactly one port. Services that land on the
+    # same public IP are annotated so the LoadBalancer implementation places
+    # them behind the same address (see ipSharing below).
+    #
+    # Requires jvb.replicaCount: 1, and an LB implementation that supports
+    # sharing one IP across several Services: MetalLB, Cilium LB-IPAM,
+    # kube-vip, loxilb. Cloud-provider NLBs (AWS/GCP/Azure/DigitalOcean) do
+    # NOT support this -- each LoadBalancer Service there gets its own
+    # address, which is the opposite of the goal. On such clouds, use
+    # useHostPort/useHostNetwork + your own external LB/DNAT instead.
+    #
+    # Because Services in a sharing group select different pods, MetalLB only
+    # allows this with externalTrafficPolicy: Cluster (see above).
+    perInstanceServices: false
+    ipSharing:
+      # Annotation key used to request IP sharing across the Services that
+      # land on the same public IP. Leave empty to disable IP-sharing
+      # annotations (only safe with one instance per public IP).
+      #   MetalLB: metallb.universe.tf/allow-shared-ip
+      #   Cilium:  io.cilium/lb-ipam-sharing-key
+      annotationKey: metallb.universe.tf/allow-shared-ip
+      # Annotation used to request a specific IP for a Service, instead of
+      # the deprecated spec.loadBalancerIP. Leave empty to fall back to
+      # spec.loadBalancerIP.
+      #   MetalLB >= 0.13: metallb.universe.tf/loadBalancerIPs
+      #   Cilium:          lbipam.cilium.io/ips
+      ipAnnotationKey: metallb.universe.tf/loadBalancerIPs
+    # extraPorts collide when several Services share one public IP. Set this
+    # to true to attach them to every per-instance Service anyway (only safe
+    # when every public IP has exactly one instance).
+    extraPortsOnEveryInstance: false
 
   livenessProbe:
     httpGet:


### PR DESCRIPTION
# Summary: 
Introduces multi‑JVB support so operators can run multiple JVB replicas behind a load balancer. This change exposes Helm values to configure the number of JVBs and related LB settings, and provides a ready sample for 1080p & 720p traffic.

## Files / locations:
 updates to Helm chart templates and `values.yaml`, plus the new sample: `values-multi-jvb-lb-1080p.yaml`.

## Motivation:
 Allow horizontal scaling of media routing to support larger conferences and improve fault tolerance without manual template edits.

## What changed:

- New/updated Helm values to control JVB replica count and load‑balancer settings.
- Added a sample values file demonstrating a multi‑JVB + LB configuration tuned for 1080p & 720p.
- Documentation notes explaining how to enable and verify multi‑JVB deployments.