### PR TITLE
Modify security settings and environment variables

### DIFF
--- a/docs/samples/values-hardened.yaml
+++ b/docs/samples/values-hardened.yaml
@@ -413,9 +413,9 @@ etherpad:
     capabilities:
       drop:
         - ALL
-    readOnlyRootFilesystem: true
+    readOnlyRootFilesystem: false
     runAsNonRoot: true
-    runAsUser: 1000
+    runAsUser: 5001
     seccompProfile:
       type: RuntimeDefault
 
@@ -438,6 +438,10 @@ etherpad:
     DEFAULT_PAD_TEXT: " "
     DISABLE_IP_LOGGING: "true"
     TRUST_PROXY: "true"
+    # Disable outgoing network calls
+    UPDATES_TIER: "off"
+    PRIVACY_UPDATE_CHECK: "false"
+    PRIVACY_PLUGIN_CATALOG: "false"
 
   extraVolumes:
     - name: tmp


### PR DESCRIPTION
Changed readOnlyRootFilesystem to false and updated runAsUser from 1000 to 5001. (https://github.com/ether/etherpad/blob/develop/docker-compose.yml#L3).

In the v3 versions the plugin migration needs additional volume permissions, which I couldn't identify, therefore would be better to allow writes bit more. Should be further inspect. Created for this also an issue at etherpad: https://github.com/ether/etherpad/issues/8084

Added environment variables to disable outgoing network calls.